### PR TITLE
include assets dir in setup.py

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -35,7 +35,7 @@ jobs:
 
     - name: Install package
       shell: bash -l {0}
-      run: pip install -e .
+      run: pip install .
 
     - name: Run pytest with coverage report
       shell: bash -l {0}

--- a/setup.py
+++ b/setup.py
@@ -108,6 +108,7 @@ setup(
             "library/*",
             "library/forcefields/*",
             "library/monomers/*",
+            "assets/*"
         ]
     },
     install_requires=REQUIRED,

--- a/setup.py
+++ b/setup.py
@@ -108,7 +108,7 @@ setup(
             "library/*",
             "library/forcefields/*",
             "library/monomers/*",
-            "assets/*"
+            "assets/*",
         ]
     },
     install_requires=REQUIRED,


### PR DESCRIPTION
The assets directory wasn't being included in `setup.py`, so when running `pip install .`  the user would not have those files.  I think this wasn't caught by tests because we used `pip install -e .` which creates symbolic links rather than copying over the package contents. I updated the `pytest.yml` file to use `pip install .`. I don't think it should cause any issues.

Solves #21 