### PR TITLE
Update and simplify environment files

### DIFF
--- a/environment-cpu.yml
+++ b/environment-cpu.yml
@@ -2,10 +2,9 @@ name: hoomd-organics
 channels:
   - conda-forge
 dependencies:
-  - boltons
   - foyer
   - freud
-    #  - gmso>=0.11.0
+  - gmso>=0.11.1
   - gsd<3.0
   - hoomd=3.11=*cpu*
   - mbuild
@@ -13,14 +12,10 @@ dependencies:
   - openbabel
   - pip
   - py3Dmol
-  - pydantic
   - pytest
   - pytest-cov
   - python=3.9
-  - symengine
-  - python-symengine
   - unyt
   - pip:
       - git+https://github.com/cmelab/cmeutils.git@master
       - git+https://github.com/cmelab/grits.git@main
-      - git+https://github.com/mosdef-hub/gmso@main

--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -1,12 +1,12 @@
-name: hoomd-organics-dev
+name: hoomd-organics
 channels:
   - conda-forge
 dependencies:
   - foyer
   - freud
-    #- gmso >= 0.11.0
+  - gmso>=0.11.1
   - gsd<3.0
-  - hoomd=3.11=*gpu*
+  - hoomd=3.11=*cpu*
   - mbuild
   - numpy
   - openbabel
@@ -20,4 +20,3 @@ dependencies:
   - pip:
       - git+https://github.com/cmelab/cmeutils.git@master
       - git+https://github.com/cmelab/grits.git@main
-      - git+https://github.com/mosdef-hub/gmso@main

--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -1,4 +1,4 @@
-name: hoomd-organics
+name: hoomd-organics-dev
 channels:
   - conda-forge
 dependencies:

--- a/environment-gpu.yml
+++ b/environment-gpu.yml
@@ -2,10 +2,9 @@ name: hoomd-organics
 channels:
   - conda-forge
 dependencies:
-  - boltons
   - foyer
   - freud
-    #  - gmso>=0.11.0
+  - gmso>=0.11.1
   - gsd<3.0
   - hoomd=3.11=*gpu*
   - mbuild
@@ -13,14 +12,10 @@ dependencies:
   - openbabel
   - pip
   - py3Dmol
-  - pydantic
   - pytest
   - pytest-cov
   - python=3.9
-  - symengine
-  - python-symengine
   - unyt
   - pip:
       - git+https://github.com/cmelab/cmeutils.git@master
       - git+https://github.com/cmelab/grits.git@main
-      - git+https://github.com/mosdef-hub/gmso@main


### PR DESCRIPTION
GMSO v0.11.1 with a couple bug fixes has been released now, so we don't need to install gmso from source via pip.