### PR TITLE
Fix scale charges, add unit tests

### DIFF
--- a/hoomd_organics/base/system.py
+++ b/hoomd_organics/base/system.py
@@ -275,8 +275,11 @@ class System(ABC):
         )
         net_charge = sum(charges)
         abs_charge = sum(abs(charges))
-        for site in self.gmso_system.sites:
-            site.charge -= abs(site.charge) * (net_charge / abs_charge)
+        if abs_charge != 0:
+            for site in self.gmso_system.sites:
+                site.charge -= abs(site.charge if site.charge else 0) * (
+                    net_charge / abs_charge
+                )
 
     def to_gsd(self, file_name):
         with gsd.hoomd.open(file_name, "wb") as traj:

--- a/hoomd_organics/base/system.py
+++ b/hoomd_organics/base/system.py
@@ -268,7 +268,6 @@ class System(ABC):
         charges = np.array([site.charge for site in self.gmso_system.sites])
         net_charge = sum(charges)
         abs_charge = sum(abs(charges))
-        charges -= abs(charges) * (net_charge / abs_charge)
         for site in self.gmso_system.sites:
             site.charge -= abs(site.charge) * (net_charge / abs_charge)
 

--- a/hoomd_organics/base/system.py
+++ b/hoomd_organics/base/system.py
@@ -150,7 +150,9 @@ class System(ABC):
 
     @property
     def net_charge(self):
-        return sum(site.charge for site in self.gmso_system.sites)
+        return sum(
+            site.charge if site.charge else 0 for site in self.gmso_system.sites
+        )
 
     @property
     def box(self):
@@ -265,7 +267,12 @@ class System(ABC):
 
     def _scale_charges(self):
         """"""
-        charges = np.array([site.charge for site in self.gmso_system.sites])
+        charges = np.array(
+            [
+                site.charge if site.charge else 0
+                for site in self.gmso_system.sites
+            ]
+        )
         net_charge = sum(charges)
         abs_charge = sum(abs(charges))
         for site in self.gmso_system.sites:

--- a/hoomd_organics/base/system.py
+++ b/hoomd_organics/base/system.py
@@ -137,9 +137,7 @@ class System(ABC):
 
     @property
     def n_particles(self):
-        if self.gmso_system:
-            return self.gmso_system.n_sites
-        return sum([mol.n_particles for mol in self.all_molecules])
+        return self.gmso_system.n_sites
 
     @property
     def mass(self):
@@ -152,8 +150,7 @@ class System(ABC):
 
     @property
     def net_charge(self):
-        if self.gmso_system:
-            return sum(site.charge for site in self.gmso_system.sites)
+        return sum(site.charge for site in self.gmso_system.sites)
 
     @property
     def box(self):

--- a/hoomd_organics/tests/base/test_system.py
+++ b/hoomd_organics/tests/base/test_system.py
@@ -242,3 +242,25 @@ class TestSystem(BaseTest):
         assert len(system.hoomd_forcefield) > 0
         assert system.n_particles == system.hoomd_snapshot.particles.N
         assert system.reference_values.keys() == {"energy", "length", "mass"}
+
+    def test_scale_charges(self, pps):
+        pps_mol = pps(num_mols=5, lengths=5)
+        no_scale = Pack(
+            molecules=pps_mol,
+            density=0.5,
+            r_cut=2.4,
+            force_field=OPLS_AA_PPS(),
+            auto_scale=True,
+            scale_charges=False,
+        )
+
+        with_scale = Pack(
+            molecules=pps_mol,
+            density=0.5,
+            r_cut=2.4,
+            force_field=OPLS_AA_PPS(),
+            auto_scale=True,
+            scale_charges=True,
+        )
+        assert abs(no_scale.net_charge.value) > abs(with_scale.net_charge.value)
+        assert np.allclose(0, with_scale.net_charge.value, atol=1e-30)

--- a/hoomd_organics/tests/base_test.py
+++ b/hoomd_organics/tests/base_test.py
@@ -176,6 +176,26 @@ class BaseTest:
         return _PolyEthylene
 
     @pytest.fixture()
+    def pps(self, pps_smiles):
+        class _PPS(Polymer):
+            def __init__(self, lengths, num_mols, **kwargs):
+                smiles = pps_smiles
+                bond_indices = [7, 10]
+                bond_length = 0.176
+                bond_orientation = [[0, 0, 1], [0, 0, -1]]
+                super().__init__(
+                    lengths=lengths,
+                    num_mols=num_mols,
+                    smiles=smiles,
+                    bond_indices=bond_indices,
+                    bond_length=bond_length,
+                    bond_orientation=bond_orientation,
+                    **kwargs
+                )
+
+        return _PPS
+
+    @pytest.fixture()
     def polyDME(self, dimethylether_smiles):
         class _PolyDME(Polymer):
             def __init__(self, lengths, num_mols, **kwargs):
@@ -219,14 +239,3 @@ class BaseTest:
             remove_hydrogens=True,
         )
         return system
-
-    # @pytest.fixture()
-    # def ua_polyethylene_system(self):
-    #     system = Pack(
-    #             molecule=PolyEthylene,
-    #             n_mols=5,
-    #             mol_kwargs={"length": 5},
-    #             density=0.5
-    #     )
-    #     system.apply_forcefield(forcefield=GAFF(), remove_hydrogens=True)
-    #     return system

--- a/hoomd_organics/utils/__init__.py
+++ b/hoomd_organics/utils/__init__.py
@@ -1,4 +1,4 @@
 from .actions import *
 from .base_types import FF_Types
 from .ff_utils import xml_to_gmso_ff
-from .utils import check_return_iterable, scale_charges
+from .utils import check_return_iterable

--- a/hoomd_organics/utils/utils.py
+++ b/hoomd_organics/utils/utils.py
@@ -8,13 +8,3 @@ def check_return_iterable(obj):
         return obj
     except:  # noqa: E722
         return [obj]
-
-
-def scale_charges(charges):
-    net_charge = sum(charges)
-    abs_charge = sum([abs(charge) for charge in charges])
-    scaled_charges = []
-    for idx, charge in enumerate(charges):
-        new_charge = charge - (abs(charge) * (net_charge / abs_charge))
-        scaled_charges.append(new_charge)
-    return scaled_charges


### PR DESCRIPTION
This PR adds the scale charges functionality to the `System` class that was previously in a separate utils files, and includes some unit tests.

It works so that each negative charge is slightly increased and each positive charge is slightly decreased (all by the same amount) to achieve as close to a neutral charge as possible.