### PR TITLE
Move reference values unit validation to utils

### DIFF
--- a/hoomd_organics/base/system.py
+++ b/hoomd_organics/base/system.py
@@ -151,7 +151,9 @@ class System(ABC):
 
     @property
     def net_charge(self):
-        return sum(site.charge for site in self.gmso_system.sites)
+        return sum(
+            site.charge if site.charge else 0 for site in self.gmso_system.sites
+        )
 
     @property
     def box(self):
@@ -231,7 +233,12 @@ class System(ABC):
 
     def _scale_charges(self):
         """"""
-        charges = np.array([site.charge for site in self.gmso_system.sites])
+        charges = np.array(
+            [
+                site.charge if site.charge else 0
+                for site in self.gmso_system.sites
+            ]
+        )
         net_charge = sum(charges)
         abs_charge = sum(abs(charges))
         for site in self.gmso_system.sites:

--- a/hoomd_organics/base/system.py
+++ b/hoomd_organics/base/system.py
@@ -178,12 +178,7 @@ class System(ABC):
 
     @reference_energy.setter
     def reference_energy(self, energy):
-        energy_dim = (
-            (u.dimensions.length**2)
-            * u.dimensions.mass
-            / u.dimensions.time**2
-        )
-        validated_energy = validate_ref_value(energy, energy_dim)
+        validated_energy = validate_ref_value(energy, u.dimensions.energy)
         self._reference_values["energy"] = validated_energy
 
     @reference_mass.setter

--- a/hoomd_organics/base/system.py
+++ b/hoomd_organics/base/system.py
@@ -16,12 +16,13 @@ from gmso.external import (
 from gmso.parameterization import apply
 
 from hoomd_organics.base.molecule import Molecule
-from hoomd_organics.utils import FF_Types, check_return_iterable, xml_to_gmso_ff
-from hoomd_organics.utils.exceptions import (
-    ForceFieldError,
-    MoleculeLoadError,
-    ReferenceUnitError,
+from hoomd_organics.utils import (
+    FF_Types,
+    check_return_iterable,
+    validate_ref_value,
+    xml_to_gmso_ff,
 )
+from hoomd_organics.utils.exceptions import ForceFieldError, MoleculeLoadError
 
 
 class System(ABC):
@@ -172,29 +173,8 @@ class System(ABC):
 
     @reference_length.setter
     def reference_length(self, length):
-        if (
-            isinstance(length, u.array.unyt_quantity)
-            and length.units.dimensions == u.dimensions.length
-        ):
-            self._reference_values["length"] = length
-        elif isinstance(length, str) and len(length.split()) == 2:
-            value, unit = length.split()
-            if value.isnumeric() and hasattr(u, unit):
-                unit = getattr(u, unit)
-                if unit.dimensions == u.dimensions.length:
-                    self._reference_values["length"] = float(value) * unit
-            else:
-                raise ReferenceUnitError(
-                    f"Invalid reference length input.Please provide reference "
-                    f"length (number) and length unit (string) or pass length "
-                    f"value as an {str(u.array.unyt_quantity)}."
-                )
-        else:
-            raise ReferenceUnitError(
-                f"Invalid reference length input.Please provide reference "
-                f"length (number) and length unit (string) or pass length "
-                f"value as an {str(u.array.unyt_quantity)}."
-            )
+        validated_length = validate_ref_value(length, u.dimensions.length)
+        self._reference_values["length"] = validated_length
 
     @reference_energy.setter
     def reference_energy(self, energy):
@@ -203,55 +183,13 @@ class System(ABC):
             * u.dimensions.mass
             / u.dimensions.time**2
         )
-        if (
-            isinstance(energy, u.array.unyt_quantity)
-            and energy.units.dimensions == energy_dim
-        ):
-            self._reference_values["energy"] = energy
-        elif isinstance(energy, str) and len(energy.split()) == 2:
-            value, unit = energy.split()
-            if value.isnumeric() and hasattr(u, unit):
-                unit = getattr(u, unit)
-                if unit.dimensions == energy_dim:
-                    self._reference_values["energy"] = float(value) * unit
-            else:
-                raise ReferenceUnitError(
-                    f"Invalid reference energy input.Please provide reference "
-                    f"energy (number) and energy unit (string) or pass energy "
-                    f"value as an {str(u.array.unyt_quantity)}."
-                )
-        else:
-            raise ReferenceUnitError(
-                f"Invalid reference energy input.Please provide reference "
-                f"energy (number) and energy unit (string) or pass energy "
-                f"value as an {str(u.array.unyt_quantity)}."
-            )
+        validated_energy = validate_ref_value(energy, energy_dim)
+        self._reference_values["energy"] = validated_energy
 
     @reference_mass.setter
     def reference_mass(self, mass):
-        if (
-            isinstance(mass, u.array.unyt_quantity)
-            and mass.units.dimensions == u.dimensions.mass
-        ):
-            self._reference_values["mass"] = mass
-        elif isinstance(mass, str) and len(mass.split()) == 2:
-            value, unit = mass.split()
-            if value.isnumeric() and hasattr(u, unit):
-                unit = getattr(u, unit)
-                if unit.dimensions == u.dimensions.mass:
-                    self._reference_values["mass"] = float(value) * unit
-            else:
-                raise ReferenceUnitError(
-                    f"Invalid reference mass input.Please provide reference "
-                    f"mass (number) and mass unit (string) or pass mass value "
-                    f"as an {str(u.array.unyt_quantity)}."
-                )
-        else:
-            raise ReferenceUnitError(
-                f"Invalid reference mass input.Please provide reference "
-                f"mass (number) and mass unit (string) or pass mass value as "
-                f"an {str(u.array.unyt_quantity)}."
-            )
+        validated_mass = validate_ref_value(mass, u.dimensions.mass)
+        self._reference_values["mass"] = validated_mass
 
     @reference_values.setter
     def reference_values(self, ref_value_dict):
@@ -259,12 +197,7 @@ class System(ABC):
         for k in ref_keys:
             if k not in ref_value_dict.keys():
                 raise ValueError(f"Missing reference for {k}.")
-            if not isinstance(ref_value_dict[k], u.array.unyt_quantity):
-                raise ReferenceUnitError(
-                    f"{k} reference value must be of type "
-                    f"{str(u.array.unyt_quantity)}"
-                )
-        self._reference_values = ref_value_dict
+            self.__setattr__(f"reference_{k}", ref_value_dict[k])
 
     @property
     def hoomd_snapshot(self):

--- a/hoomd_organics/base/system.py
+++ b/hoomd_organics/base/system.py
@@ -241,8 +241,11 @@ class System(ABC):
         )
         net_charge = sum(charges)
         abs_charge = sum(abs(charges))
-        for site in self.gmso_system.sites:
-            site.charge -= abs(site.charge) * (net_charge / abs_charge)
+        if abs_charge != 0:
+            for site in self.gmso_system.sites:
+                site.charge -= abs(site.charge if site.charge else 0) * (
+                    net_charge / abs_charge
+                )
 
     def to_gsd(self, file_name):
         with gsd.hoomd.open(file_name, "wb") as traj:

--- a/hoomd_organics/base/system.py
+++ b/hoomd_organics/base/system.py
@@ -234,7 +234,6 @@ class System(ABC):
         charges = np.array([site.charge for site in self.gmso_system.sites])
         net_charge = sum(charges)
         abs_charge = sum(abs(charges))
-        charges -= abs(charges) * (net_charge / abs_charge)
         for site in self.gmso_system.sites:
             site.charge -= abs(site.charge) * (net_charge / abs_charge)
 

--- a/hoomd_organics/base/system.py
+++ b/hoomd_organics/base/system.py
@@ -152,6 +152,11 @@ class System(ABC):
         return sum(mol.mass for mol in self.all_molecules)
 
     @property
+    def net_charge(self):
+        if self.gmso_system:
+            return sum(site.charge for site in self.gmso_system.sites)
+
+    @property
     def box(self):
         return self.system.box
 
@@ -227,6 +232,15 @@ class System(ABC):
         if len(hydrogens) > 0:
             self.gmso_system = from_parmed(parmed_struc)
 
+    def _scale_charges(self):
+        """"""
+        charges = np.array([site.charge for site in self.gmso_system.sites])
+        net_charge = sum(charges)
+        abs_charge = sum(abs(charges))
+        charges -= abs(charges) * (net_charge / abs_charge)
+        for site in self.gmso_system.sites:
+            site.charge -= abs(site.charge) * (net_charge / abs_charge)
+
     def to_gsd(self, file_name):
         with gsd.hoomd.open(file_name, "wb") as traj:
             traj.append(self.hoomd_snapshot)
@@ -272,8 +286,7 @@ class System(ABC):
             for site in self.gmso_system.sites:
                 site.charge = 0
         if self.scale_charges and not self.remove_charges:
-            pass
-            # TODO: Scale charges from self.gmso_system
+            self._scale_charges()
         epsilons = [
             s.atom_type.parameters["epsilon"] for s in self.gmso_system.sites
         ]

--- a/hoomd_organics/base/system.py
+++ b/hoomd_organics/base/system.py
@@ -138,9 +138,7 @@ class System(ABC):
 
     @property
     def n_particles(self):
-        if self.gmso_system:
-            return self.gmso_system.n_sites
-        return sum([mol.n_particles for mol in self.all_molecules])
+        return self.gmso_system.n_sites
 
     @property
     def mass(self):
@@ -153,8 +151,7 @@ class System(ABC):
 
     @property
     def net_charge(self):
-        if self.gmso_system:
-            return sum(site.charge for site in self.gmso_system.sites)
+        return sum(site.charge for site in self.gmso_system.sites)
 
     @property
     def box(self):

--- a/hoomd_organics/tests/base/test_system.py
+++ b/hoomd_organics/tests/base/test_system.py
@@ -456,7 +456,7 @@ class TestSystem(BaseTest):
             auto_scale=False,
         )
         with pytest.raises(ReferenceUnitError):
-            system.reference_length = "1.0 m"
+            system.reference_energy = "1.0 m"
 
     def test_set_ref_mass(self, polyethylene):
         polyethylene = polyethylene(lengths=5, num_mols=1)
@@ -541,7 +541,7 @@ class TestSystem(BaseTest):
             auto_scale=False,
         )
         with pytest.raises(ReferenceUnitError):
-            system.reference_length = "1.0 m"
+            system.reference_mass = "1.0 m"
 
     def test_lattice_polymer(self, polyethylene):
         polyethylene = polyethylene(lengths=2, num_mols=32)

--- a/hoomd_organics/tests/base/test_system.py
+++ b/hoomd_organics/tests/base/test_system.py
@@ -219,12 +219,31 @@ class TestSystem(BaseTest):
         ref_value_dict = {
             "length": 1 * u.angstrom,
             "energy": 3.0 * u.kcal / u.mol,
-            "mass": 1.25 * u.amu,
+            "mass": 1.25 * u.Unit("amu"),
         }
         system.reference_values = ref_value_dict
         assert system.reference_length == ref_value_dict["length"]
         assert system.reference_energy == ref_value_dict["energy"]
         assert system.reference_mass == ref_value_dict["mass"]
+
+    def test_set_ref_values_string(self, polyethylene):
+        polyethylene = polyethylene(lengths=5, num_mols=1)
+        system = Pack(
+            molecules=[polyethylene],
+            force_field=[OPLS_AA()],
+            density=1.0,
+            r_cut=2.5,
+            auto_scale=False,
+        )
+        ref_value_dict = {
+            "length": "1 angstrom",
+            "energy": "3 kcal/mol",
+            "mass": "1.25 amu",
+        }
+        system.reference_values = ref_value_dict
+        assert system.reference_length == 1 * u.angstrom
+        assert system.reference_energy == 3 * u.kcal / u.mol
+        assert system.reference_mass == 1.25 * u.amu
 
     def test_set_ref_values_missing_key(self, polyethylene):
         polyethylene = polyethylene(lengths=5, num_mols=1)

--- a/hoomd_organics/tests/base/test_system.py
+++ b/hoomd_organics/tests/base/test_system.py
@@ -580,3 +580,25 @@ class TestSystem(BaseTest):
         assert len(system.hoomd_forcefield) > 0
         assert system.n_particles == system.hoomd_snapshot.particles.N
         assert system.reference_values.keys() == {"energy", "length", "mass"}
+
+    def test_scale_charges(self, pps):
+        pps_mol = pps(num_mols=5, lengths=5)
+        no_scale = Pack(
+            molecules=pps_mol,
+            density=0.5,
+            r_cut=2.4,
+            force_field=OPLS_AA_PPS(),
+            auto_scale=True,
+            scale_charges=False,
+        )
+
+        with_scale = Pack(
+            molecules=pps_mol,
+            density=0.5,
+            r_cut=2.4,
+            force_field=OPLS_AA_PPS(),
+            auto_scale=True,
+            scale_charges=True,
+        )
+        assert abs(no_scale.net_charge.value) > abs(with_scale.net_charge.value)
+        assert np.allclose(0, with_scale.net_charge.value, atol=1e-30)

--- a/hoomd_organics/tests/base/test_system.py
+++ b/hoomd_organics/tests/base/test_system.py
@@ -398,6 +398,18 @@ class TestSystem(BaseTest):
         system.reference_energy = "1 kJ"
         assert system.reference_energy == 1 * u.kJ
 
+    def test_ref_energy_string_comb_units(self, polyethylene):
+        polyethylene = polyethylene(lengths=5, num_mols=1)
+        system = Pack(
+            molecules=[polyethylene],
+            force_field=[OPLS_AA()],
+            density=1.0,
+            r_cut=2.5,
+            auto_scale=False,
+        )
+        system.reference_energy = "1 kcal/mol"
+        assert system.reference_energy == 1 * u.kcal / u.mol
+
     def test_ref_energy_invalid_string(self, polyethylene):
         polyethylene = polyethylene(lengths=5, num_mols=1)
         system = Pack(

--- a/hoomd_organics/tests/base_test.py
+++ b/hoomd_organics/tests/base_test.py
@@ -160,6 +160,26 @@ class BaseTest:
         return _PolyEthylene
 
     @pytest.fixture()
+    def pps(self, pps_smiles):
+        class _PPS(Polymer):
+            def __init__(self, lengths, num_mols, **kwargs):
+                smiles = pps_smiles
+                bond_indices = [7, 10]
+                bond_length = 0.176
+                bond_orientation = [[0, 0, 1], [0, 0, -1]]
+                super().__init__(
+                    lengths=lengths,
+                    num_mols=num_mols,
+                    smiles=smiles,
+                    bond_indices=bond_indices,
+                    bond_length=bond_length,
+                    bond_orientation=bond_orientation,
+                    **kwargs
+                )
+
+        return _PPS
+
+    @pytest.fixture()
     def polyDME(self, dimethylether_smiles):
         class _PolyDME(Polymer):
             def __init__(self, lengths, num_mols, **kwargs):

--- a/hoomd_organics/tests/utils/test_utils.py
+++ b/hoomd_organics/tests/utils/test_utils.py
@@ -1,0 +1,40 @@
+import pytest
+import unyt as u
+
+from hoomd_organics.utils import check_return_iterable, validate_ref_value
+from hoomd_organics.utils.exceptions import ReferenceUnitError
+
+
+class TestUtils:
+    def test_check_return_iterable(self):
+        assert check_return_iterable("test") == ["test"]
+        assert check_return_iterable(["test"]) == ["test"]
+        assert check_return_iterable({"test": "test"}) == [{"test": "test"}]
+        assert check_return_iterable(1) == [1]
+        assert check_return_iterable(1.0) == [1.0]
+        assert check_return_iterable([1, 2, 3]) == [1, 2, 3]
+        assert check_return_iterable({"test": 1}) == [{"test": 1}]
+        assert check_return_iterable({"test": 1, "test2": 2}) == [
+            {"test": 1, "test2": 2}
+        ]
+
+    def test_validate_ref_value(self):
+        assert validate_ref_value(1.0 * u.g, u.dimensions.mass) == 1.0 * u.g
+        assert validate_ref_value("1.0 g", u.dimensions.mass) == 1.0 * u.g
+        assert validate_ref_value("1.0 kcal/mol", u.dimensions.energy) == (
+            1.0 * u.kcal / u.mol
+        )
+        assert validate_ref_value("1.0 amu", u.dimensions.mass) == 1.0 * u.Unit(
+            "amu"
+        )
+        with pytest.raises(ReferenceUnitError):
+            validate_ref_value("1.0 g", u.dimensions.energy)
+
+        with pytest.raises(ReferenceUnitError):
+            validate_ref_value("1.0 kcal/invalid", u.dimensions.energy)
+
+        with pytest.raises(ReferenceUnitError):
+            validate_ref_value("1.0 invalid", u.dimensions.energy)
+
+        with pytest.raises(ValueError):
+            validate_ref_value("test g", u.dimensions.mass)

--- a/hoomd_organics/utils/__init__.py
+++ b/hoomd_organics/utils/__init__.py
@@ -1,4 +1,4 @@
 from .actions import *
 from .base_types import FF_Types
 from .ff_utils import xml_to_gmso_ff
-from .utils import check_return_iterable, scale_charges
+from .utils import check_return_iterable, scale_charges, validate_ref_value

--- a/hoomd_organics/utils/__init__.py
+++ b/hoomd_organics/utils/__init__.py
@@ -1,4 +1,4 @@
 from .actions import *
 from .base_types import FF_Types
 from .ff_utils import xml_to_gmso_ff
-from .utils import check_return_iterable, scale_charges, validate_ref_value
+from .utils import check_return_iterable, validate_ref_value

--- a/hoomd_organics/utils/utils.py
+++ b/hoomd_organics/utils/utils.py
@@ -15,16 +15,6 @@ def check_return_iterable(obj):
         return [obj]
 
 
-def scale_charges(charges):
-    net_charge = sum(charges)
-    abs_charge = sum([abs(charge) for charge in charges])
-    scaled_charges = []
-    for idx, charge in enumerate(charges):
-        new_charge = charge - (abs(charge) * (net_charge / abs_charge))
-        scaled_charges.append(new_charge)
-    return scaled_charges
-
-
 def validate_ref_value(ref_value, dimension):
     """Validates the reference value and checks the unit dimension.
     This function validates the reference value. The reference value can be
@@ -84,7 +74,7 @@ def validate_ref_value(ref_value, dimension):
 
     # if ref_value is an instance of unyt_quantity, check the dimension.
     if isinstance(ref_value, u.unyt_quantity) and _is_valid_dimension(
-        ref_value.units
+            ref_value.units
     ):
         return ref_value
     # if ref_value is a string, check if it is a number and if it is, check if

--- a/hoomd_organics/utils/utils.py
+++ b/hoomd_organics/utils/utils.py
@@ -49,7 +49,7 @@ def validate_ref_value(ref_value, dimension):
         if ref_unit.dimensions != dimension:
             raise ReferenceUnitError(
                 f"Invalid unit dimension. The reference "
-                f"value must be in {dimension.name} "
+                f"value must be in {dimension} "
                 f"dimension."
             )
         return True
@@ -73,7 +73,7 @@ def validate_ref_value(ref_value, dimension):
         raise ReferenceUnitError(
             f"Invalid reference value. Please provide "
             f"a reference value with unit of "
-            f"{dimension.name} dimension."
+            f"{dimension} dimension."
         )
 
     def _is_float(num):
@@ -97,5 +97,5 @@ def validate_ref_value(ref_value, dimension):
         raise ReferenceUnitError(
             f"Invalid reference value. Please provide "
             f"a reference value with unit of "
-            f"{dimension.name} dimension."
+            f"{dimension} dimension."
         )

--- a/hoomd_organics/utils/utils.py
+++ b/hoomd_organics/utils/utils.py
@@ -74,7 +74,7 @@ def validate_ref_value(ref_value, dimension):
 
     # if ref_value is an instance of unyt_quantity, check the dimension.
     if isinstance(ref_value, u.unyt_quantity) and _is_valid_dimension(
-            ref_value.units
+        ref_value.units
     ):
         return ref_value
     # if ref_value is a string, check if it is a number and if it is, check if

--- a/hoomd_organics/utils/utils.py
+++ b/hoomd_organics/utils/utils.py
@@ -14,6 +14,7 @@ def check_return_iterable(obj):
     except:  # noqa: E722
         return [obj]
 
+
 def validate_ref_value(ref_value, dimension):
     """Validates the reference value and checks the unit dimension.
     This function validates the reference value. The reference value can be

--- a/hoomd_organics/utils/utils.py
+++ b/hoomd_organics/utils/utils.py
@@ -56,7 +56,10 @@ def validate_ref_value(ref_value, dimension):
 
     def _parse_and_validate_unit(value, unit_str):
         if hasattr(u, unit_str):
-            u_unit = getattr(u, unit_str)
+            if unit_str == "amu":
+                u_unit = u.Unit("amu")
+            else:
+                u_unit = getattr(u, unit_str)
             if _is_valid_dimension(u_unit):
                 return float(value) * u_unit
         # if the unit contains "/" character, for example "g/mol", check if
@@ -73,6 +76,12 @@ def validate_ref_value(ref_value, dimension):
             f"{dimension.name} dimension."
         )
 
+    def _is_float(num):
+        try:
+            return float(num)
+        except ValueError:
+            raise ValueError("The reference value is not a number.")
+
     # if ref_value is an instance of unyt_quantity, check the dimension.
     if isinstance(ref_value, u.unyt_quantity) and _is_valid_dimension(
         ref_value.units
@@ -82,8 +91,7 @@ def validate_ref_value(ref_value, dimension):
     # the unit exists in unyt and has the correct dimension.
     elif isinstance(ref_value, str) and len(ref_value.split()) == 2:
         value, unit_str = ref_value.split()
-        if not value.isnumeric():
-            raise ReferenceUnitError("The reference value is not a number.")
+        value = _is_float(value)
         return _parse_and_validate_unit(value, unit_str)
     else:
         raise ReferenceUnitError(

--- a/hoomd_organics/utils/utils.py
+++ b/hoomd_organics/utils/utils.py
@@ -1,3 +1,8 @@
+import unyt as u
+
+from hoomd_organics.utils.exceptions import ReferenceUnitError
+
+
 def check_return_iterable(obj):
     if isinstance(obj, dict):
         return [obj]
@@ -18,3 +23,71 @@ def scale_charges(charges):
         new_charge = charge - (abs(charge) * (net_charge / abs_charge))
         scaled_charges.append(new_charge)
     return scaled_charges
+
+
+def validate_ref_value(ref_value, dimension):
+    """Validates the reference value and checks the unit dimension.
+    This function validates the reference value. The reference value can be
+    provided in three ways:
+        1. An unyt_quantity instance.
+        2. A string with the value and unit , for example "1.0 g".
+        3. A string with the value and unit separated by a "/", for example
+        "1.0 kcal/mol".
+    Parameters
+    ----------
+    ref_value : unyt_quantity or str; required
+        The reference value.
+    dimension : unyt_dimension; required
+        The dimension of the reference value.
+
+    Returns
+    -------
+    The validated reference value as an unyt.unyt_quantity instance.
+    """
+
+    def _is_valid_dimension(ref_unit):
+        if ref_unit.dimensions != dimension:
+            raise ReferenceUnitError(
+                f"Invalid unit dimension. The reference "
+                f"value must be in {dimension.name} "
+                f"dimension."
+            )
+        return True
+
+    def _parse_and_validate_unit(value, unit_str):
+        if hasattr(u, unit_str):
+            u_unit = getattr(u, unit_str)
+            if _is_valid_dimension(u_unit):
+                return float(value) * u_unit
+        # if the unit contains "/" character, for example "g/mol", check if
+        # the unit is a valid unit and has the correct dimension.
+        if len(unit_str.split("/")) == 2:
+            unit1, unit2 = unit_str.split("/")
+            if hasattr(u, unit1) and hasattr(u, unit2):
+                comb_unit = getattr(u, unit1) / getattr(u, unit2)
+                if _is_valid_dimension(comb_unit):
+                    return float(value) * comb_unit
+        raise ReferenceUnitError(
+            f"Invalid reference value. Please provide "
+            f"a reference value with unit of "
+            f"{dimension.name} dimension."
+        )
+
+    # if ref_value is an instance of unyt_quantity, check the dimension.
+    if isinstance(ref_value, u.unyt_quantity) and _is_valid_dimension(
+        ref_value.units
+    ):
+        return ref_value
+    # if ref_value is a string, check if it is a number and if it is, check if
+    # the unit exists in unyt and has the correct dimension.
+    elif isinstance(ref_value, str) and len(ref_value.split()) == 2:
+        value, unit_str = ref_value.split()
+        if not value.isnumeric():
+            raise ReferenceUnitError("The reference value is not a number.")
+        return _parse_and_validate_unit(value, unit_str)
+    else:
+        raise ReferenceUnitError(
+            f"Invalid reference value. Please provide "
+            f"a reference value with unit of "
+            f"{dimension.name} dimension."
+        )


### PR DESCRIPTION
This PR moves a bunch of duplicated codes that validates reference units to the utils module. 
Unit tests have been added for all new functionalities. 