### PR TITLE
Fix mismatched gmso residue name when molecule is loaded from mol2

### DIFF
--- a/hoomd_organics/base/molecule.py
+++ b/hoomd_organics/base/molecule.py
@@ -261,6 +261,12 @@ class Molecule:
     def assign_mol_name(self, name):
         for mol in self.molecules:
             mol.name = name
+            # TODO: This is a hack to make sure that the name of the children is
+            # also updated, so that when converting to gmso, all the sites have
+            # the correct name. This needs additional investigation into gmso's
+            # convert mbuilder to gmso functionality.
+            for child in mol.children:
+                child.name = name
 
 
 class Polymer(Molecule):

--- a/hoomd_organics/tests/base/test_system.py
+++ b/hoomd_organics/tests/base/test_system.py
@@ -26,6 +26,7 @@ class TestSystem(BaseTest):
         )
         assert system.n_mol_types == 1
         assert len(system.all_molecules) == len(benzene_mols.molecules)
+        assert system.gmso_system.is_typed()
         assert len(system.hoomd_forcefield) > 0
         assert system.n_particles == system.hoomd_snapshot.particles.N
         assert system.hoomd_snapshot.particles.types == ["opls_145", "opls_146"]
@@ -47,6 +48,7 @@ class TestSystem(BaseTest):
         )
         assert system.all_molecules[0].name == "0"
         assert system.all_molecules[-1].name == "1"
+        assert system.gmso_system.is_typed()
         assert len(system.hoomd_forcefield) > 0
         assert system.n_particles == system.hoomd_snapshot.particles.N
         assert system.hoomd_snapshot.particles.types == [
@@ -74,6 +76,7 @@ class TestSystem(BaseTest):
         ) + len(pps_mol.molecules)
         assert system.all_molecules[0].name == "0"
         assert system.all_molecules[-1].name == "1"
+        assert system.gmso_system.is_typed()
         assert len(system.hoomd_forcefield) > 0
         for hoomd_force in system.hoomd_forcefield:
             if isinstance(hoomd_force, hoomd.md.pair.LJ):
@@ -113,6 +116,7 @@ class TestSystem(BaseTest):
             auto_scale=True,
             remove_hydrogens=True,
         )
+        assert system.gmso_system.is_typed()
         assert len(system.hoomd_forcefield) > 0
         assert list(system.hoomd_forcefield[0].params.keys()) == [
             ("opls_145", "opls_145")

--- a/hoomd_organics/tests/base/test_system.py
+++ b/hoomd_organics/tests/base/test_system.py
@@ -90,7 +90,7 @@ class TestSystem(BaseTest):
             "sh",
         ]
 
-    def test_mol_from_mol2_ff_dictionary(self, benzene_molecule_mol2):
+    def test_system_from_mol2_mol_parameterization(self, benzene_molecule_mol2):
         benzene_mol = benzene_molecule_mol2(n_mols=3)
         system = Pack(
             molecules=[benzene_mol],

--- a/hoomd_organics/tests/base/test_system.py
+++ b/hoomd_organics/tests/base/test_system.py
@@ -90,6 +90,19 @@ class TestSystem(BaseTest):
             "sh",
         ]
 
+    def test_mol_from_mol2_ff_dictionary(self, benzene_molecule_mol2):
+        benzene_mol = benzene_molecule_mol2(n_mols=3)
+        system = Pack(
+            molecules=[benzene_mol],
+            density=0.8,
+            r_cut=2.5,
+            force_field=OPLS_AA(),
+            auto_scale=True,
+        )
+        assert system.gmso_system.is_typed()
+        assert len(system.hoomd_forcefield) > 0
+        assert system.n_particles == system.hoomd_snapshot.particles.N
+
     def test_remove_hydrogen(self, benzene_molecule):
         benzene_mol = benzene_molecule(n_mols=3)
         system = Pack(

--- a/hoomd_organics/tests/base_test.py
+++ b/hoomd_organics/tests/base_test.py
@@ -114,6 +114,14 @@ class BaseTest:
         return _benzene_molecule
 
     @pytest.fixture()
+    def benzene_molecule_mol2(self, benzene_mol2):
+        def _benzene_molecule(n_mols):
+            benzene = Molecule(num_mols=n_mols, file=benzene_mol2)
+            return benzene
+
+        return _benzene_molecule
+
+    @pytest.fixture()
     def ethane_molecule(self, ethane_smiles):
         def _ethane_molecule(n_mols):
             ethane = Molecule(num_mols=n_mols, smiles=ethane_smiles)


### PR DESCRIPTION
This PR fixes the gmso topology parameterization issue caused by name mismatch in mbuild compound.
For a Molecule loaded from a mol2 file, if we change the mbuild compound name, the name of its children does not change accordingly. When the forcefield dictionary with keys similar to the compound name is being applied to the system, the gmso topology is not parameterized because of this naming mismach. 

As a quick fix, this PR makes sure that the name is assigned to every child of the mbuild compound. However, more investigation needs to be done on gmso's behavior when converting an mbuild compound to a topology. (see the example in the comments).