### PR TITLE
Migrate to hoomd v4

### DIFF
--- a/environment-cpu.yml
+++ b/environment-cpu.yml
@@ -6,7 +6,7 @@ dependencies:
   - foyer
   - freud
   - gsd<3.0
-  - hoomd=4.2=*cpu*
+  - hoomd=4.1=*cpu*
   - mbuild
   - numpy
   - openbabel

--- a/environment-cpu.yml
+++ b/environment-cpu.yml
@@ -6,7 +6,7 @@ dependencies:
   - foyer
   - freud
   - gsd<3.0
-  - hoomd=3.11=*cpu*
+  - hoomd=4.1=*cpu*
   - mbuild
   - numpy
   - openbabel

--- a/environment-cpu.yml
+++ b/environment-cpu.yml
@@ -6,7 +6,7 @@ dependencies:
   - foyer
   - freud
   - gsd<3.0
-  - hoomd=4.1=*cpu*
+  - hoomd=4.2=*cpu*
   - mbuild
   - numpy
   - openbabel

--- a/environment-gpu.yml
+++ b/environment-gpu.yml
@@ -6,7 +6,7 @@ dependencies:
   - foyer
   - freud
   - gsd<3.0
-  - hoomd=4.1=*gpu*
+  - hoomd=4.2=*gpu*
   - mbuild
   - numpy
   - openbabel

--- a/environment-gpu.yml
+++ b/environment-gpu.yml
@@ -6,7 +6,7 @@ dependencies:
   - foyer
   - freud
   - gsd<3.0
-  - hoomd=3.11=*gpu*
+  - hoomd=4.1=*gpu*
   - mbuild
   - numpy
   - openbabel

--- a/environment-gpu.yml
+++ b/environment-gpu.yml
@@ -6,7 +6,7 @@ dependencies:
   - foyer
   - freud
   - gsd<3.0
-  - hoomd=4.2=*gpu*
+  - hoomd=4.1=*gpu*
   - mbuild
   - numpy
   - openbabel

--- a/hoomd_organics/base/simulation.py
+++ b/hoomd_organics/base/simulation.py
@@ -741,7 +741,7 @@ class Simulation(hoomd.simulation.Simulation):
             trigger=hoomd.trigger.Periodic(int(self.gsd_write_freq)),
             mode="wb",
             dynamic=["momentum", "property"],
-            filter=self.integrate_group,
+            filter=hoomd.filter.All(),
             logger=gsd_logger,
         )
 

--- a/hoomd_organics/base/simulation.py
+++ b/hoomd_organics/base/simulation.py
@@ -739,7 +739,8 @@ class Simulation(hoomd.simulation.Simulation):
             filename=self.gsd_file_name,
             trigger=hoomd.trigger.Periodic(int(self.gsd_write_freq)),
             mode="wb",
-            dynamic=["momentum"],
+            dynamic=["momentum", "property"],
+            filter=self.integrate_group,
             logger=gsd_logger,
         )
 

--- a/hoomd_organics/base/simulation.py
+++ b/hoomd_organics/base/simulation.py
@@ -68,6 +68,7 @@ class Simulation(hoomd.simulation.Simulation):
         gsd_file_name="trajectory.gsd",
         log_write_freq=1e3,
         log_file_name="sim_data.txt",
+        thermostat=HOOMDThermostats.MTTK,
     ):
         super(Simulation, self).__init__(device, seed)
         self.initial_state = initial_state
@@ -97,7 +98,7 @@ class Simulation(hoomd.simulation.Simulation):
         self._create_state(self.initial_state)
         # Add a gsd and thermo props logger to sim operations
         self._add_hoomd_writers()
-        self._thermostat = HOOMDThermostats.BUSSI
+        self._thermostat = thermostat
 
     @classmethod
     def from_system(cls, system, **kwargs):

--- a/hoomd_organics/base/simulation.py
+++ b/hoomd_organics/base/simulation.py
@@ -8,6 +8,7 @@ import numpy as np
 import unyt as u
 
 from hoomd_organics.utils import (
+    HOOMDThermostats,
     StdOutLogger,
     UpdateWalls,
     calculate_box_length,
@@ -95,6 +96,7 @@ class Simulation(hoomd.simulation.Simulation):
         self._create_state(self.initial_state)
         # Add a gsd and thermo props logger to sim operations
         self._add_hoomd_writers()
+        self._thermostat = HOOMDThermostats.BUSSI
 
     @classmethod
     def from_system(cls, system, **kwargs):
@@ -280,6 +282,20 @@ class Simulation(hoomd.simulation.Simulation):
                 "These will be set once one of the run functions "
                 "have been called for the first time."
             )
+
+    @property
+    def thermostat(self):
+        return self._thermostat
+
+    @thermostat.setter
+    def thermostat(self, thermostat):
+        if not issubclass(
+            self._thermostat, hoomd.md.methods.thermostats.Thermostat
+        ):
+            raise ValueError(
+                f"Invalid thermostat. Please choose from: {HOOMDThermostats}"
+            )
+        self._thermostat = thermostat
 
     def add_force(self, hoomd_force):
         """"""

--- a/hoomd_organics/library/simulations/tensile.py
+++ b/hoomd_organics/library/simulations/tensile.py
@@ -91,7 +91,7 @@ class Tensile(Simulation):
         self.operations.updaters.append(box_resizer)
         self.operations.updaters.append(particle_updater)
         self.set_integrator_method(
-            integrator_method=hoomd.md.methods.NVE,
+            integrator_method=hoomd.md.methods.ConstantVolume,
             method_kwargs={"filter": self.integrate_group},
         )
         self.run(n_steps + 1)

--- a/hoomd_organics/tests/base/test_simulation.py
+++ b/hoomd_organics/tests/base/test_simulation.py
@@ -309,6 +309,7 @@ class TestSimulate(BaseTest):
     def test_gsd_logger(self, benzene_system):
         sim = Simulation.from_system(benzene_system, gsd_write_freq=1)
         sim.run_NVT(n_steps=5, kT=1.0, tau_kt=0.001)
+        sim.operations.writers[-2].flush()
         expected_gsd_quantities = [
             "hoomd_organics/base/simulation/Simulation/timestep",
             "hoomd_organics/base/simulation/Simulation/tps",

--- a/hoomd_organics/tests/base/test_simulation.py
+++ b/hoomd_organics/tests/base/test_simulation.py
@@ -98,7 +98,7 @@ class TestSimulate(BaseTest):
     def test_NVT(self, benzene_system):
         sim = Simulation.from_system(benzene_system)
         sim.run_NVT(kT=1.0, tau_kt=0.01, n_steps=500)
-        assert isinstance(sim.method, hoomd.md.methods.NVT)
+        assert isinstance(sim.method, hoomd.md.methods.ConstantVolume)
 
     def test_NPT(self, benzene_system):
         sim = Simulation.from_system(benzene_system)
@@ -109,17 +109,17 @@ class TestSimulate(BaseTest):
             tau_kt=0.001,
             tau_pressure=0.01,
         )
-        assert isinstance(sim.method, hoomd.md.methods.NPT)
+        assert isinstance(sim.method, hoomd.md.methods.ConstantPressure)
 
     def test_langevin(self, benzene_system):
         sim = Simulation.from_system(benzene_system)
-        sim.run_langevin(n_steps=500, kT=1.0, alpha=0.5)
+        sim.run_langevin(n_steps=500, kT=1.0)
         assert isinstance(sim.method, hoomd.md.methods.Langevin)
 
     def test_NVE(self, benzene_system):
         sim = Simulation.from_system(benzene_system)
         sim.run_NVE(n_steps=500)
-        assert isinstance(sim.method, hoomd.md.methods.NVE)
+        assert isinstance(sim.method, hoomd.md.methods.ConstantVolume)
 
     def test_displacement_cap(self, benzene_system):
         sim = Simulation.from_system(benzene_system)
@@ -206,11 +206,11 @@ class TestSimulate(BaseTest):
     def test_change_methods(self, benzene_system):
         sim = Simulation.from_system(benzene_system)
         sim.run_NVT(kT=1.0, tau_kt=0.01, n_steps=0)
-        assert isinstance(sim.method, hoomd.md.methods.NVT)
+        assert isinstance(sim.method, hoomd.md.methods.ConstantVolume)
         sim.run_NPT(
             kT=1.0, tau_kt=0.01, tau_pressure=0.1, pressure=0.001, n_steps=0
         )
-        assert isinstance(sim.method, hoomd.md.methods.NPT)
+        assert isinstance(sim.method, hoomd.md.methods.ConstantPressure)
 
     def test_change_dt(self, benzene_system):
         sim = Simulation.from_system(benzene_system)

--- a/hoomd_organics/utils/__init__.py
+++ b/hoomd_organics/utils/__init__.py
@@ -1,5 +1,5 @@
 from .actions import *
-from .base_types import FF_Types
+from .base_types import FF_Types, HOOMDThermostats
 from .ff_utils import xml_to_gmso_ff
 from .utils import (
     calculate_box_length,

--- a/hoomd_organics/utils/base_types.py
+++ b/hoomd_organics/utils/base_types.py
@@ -1,3 +1,6 @@
+import hoomd
+
+
 class FF_Types:
     opls = "opls"
     pps_opls = "pps_opls"
@@ -5,3 +8,9 @@ class FF_Types:
     gaff = "gaff"
     custom = "custom"
     Hoomd = "Hoomd"
+
+
+class HOOMDThermostats:
+    BERENDSEN = hoomd.md.methods.thermostats.Berendsen
+    BUSSI = hoomd.md.methods.thermostats.Bussi
+    MTTK = hoomd.md.methods.thermostats.MTTK


### PR DESCRIPTION
This PR upgrades the hoomd version to 4.1 and updates the `Simulation` class based on the changed on HOOMD 4.

The main changes are around setting up the integrator methods and thermostats.

Basically, in HOOMD v4 `NVT` and `NVE` methods are replaced with `hoomd.md.methods.ConstantVolume` and `NPT` method is replaced with `hoomd.md.methods.ConstantPressure`. 
In methods with constant a T, a thermostat needs to added from `hoomd.md.methods.thermostats".

Hoomd documentation for migrating to V4: https://hoomd-blue.readthedocs.io/en/v4.1.0/migrating.html#migrating-to-hoomd-v4


I still need to add some unit tests for thermostat setter. 