### PR TITLE
Change behavior of hoomd object properties

### DIFF
--- a/hoomd_organics/base/system.py
+++ b/hoomd_organics/base/system.py
@@ -123,7 +123,9 @@ class System(ABC):
             self._apply_forcefield()
         if self.remove_hydrogens:
             self._remove_hydrogens()
-        self._hoomd_forcefield = self._create_hoomd_forcefield() if self._force_field else None
+        self._hoomd_forcefield = (
+            self._create_hoomd_forcefield() if self._force_field else None
+        )
         self._hoomd_snapshot = self._create_hoomd_snapshot()
 
     @abstractmethod
@@ -324,7 +326,6 @@ class System(ABC):
         self._reference_values["energy"] = energy_scale * epsilons[0].unit_array
         self._reference_values["length"] = length_scale * sigmas[0].unit_array
         self._reference_values["mass"] = mass_scale * masses[0].unit_array
-
 
     def set_target_box(
         self, x_constraint=None, y_constraint=None, z_constraint=None

--- a/hoomd_organics/base/system.py
+++ b/hoomd_organics/base/system.py
@@ -209,7 +209,7 @@ class System(ABC):
 
     @property
     def hoomd_forcefield(self):
-        if self._ff_refs != self.reference_values:
+        if self._ff_refs != self.reference_values and self._force_field:
             self._hoomd_forcefield = self._create_hoomd_forcefield()
         return self._hoomd_forcefield
 

--- a/hoomd_organics/base/system.py
+++ b/hoomd_organics/base/system.py
@@ -124,7 +124,7 @@ class System(ABC):
         if self.remove_hydrogens:
             self._remove_hydrogens()
         self._hoomd_forcefield = (
-            self._create_hoomd_forcefield() if self._force_field else None
+            self._create_hoomd_forcefield() if self._force_field else [] 
         )
         self._hoomd_snapshot = self._create_hoomd_snapshot()
 
@@ -272,21 +272,18 @@ class System(ABC):
         return topology
 
     def _create_hoomd_forcefield(self):
-        if self._force_field:
-            force_list = []
-            ff, refs = to_hoomd_forcefield(
-                top=self.gmso_system,
-                r_cut=self.r_cut,
-                auto_scale=self.auto_scale,
-                base_units=self._reference_values
-                if self._reference_values
-                else None,
-            )
-            for force in ff:
-                force_list.extend(ff[force])
-            return force_list
-        else:
-            return []
+        force_list = []
+        ff, refs = to_hoomd_forcefield(
+            top=self.gmso_system,
+            r_cut=self.r_cut,
+            auto_scale=self.auto_scale,
+            base_units=self._reference_values
+            if self._reference_values
+            else None,
+        )
+        for force in ff:
+            force_list.extend(ff[force])
+        return force_list
 
     def _create_hoomd_snapshot(self):
         snap, refs = to_gsd_snapshot(

--- a/hoomd_organics/base/system.py
+++ b/hoomd_organics/base/system.py
@@ -63,6 +63,9 @@ class System(ABC):
         self._hoomd_forcefield = []
         self._reference_values = base_units
         self._gmso_forcefields_dict = dict()
+        # Reference values used when last writing snapshot and forcefields
+        self._ff_refs = dict()
+        self._snap_refs = dict()
         self.gmso_system = None
 
         # Collecting all molecules
@@ -200,10 +203,14 @@ class System(ABC):
 
     @property
     def hoomd_snapshot(self):
+        if self._snap_refs != self.reference_values:
+            self._hoomd_snapshot = self._create_hoomd_snapshot()
         return self._hoomd_snapshot
 
     @property
     def hoomd_forcefield(self):
+        if self._ff_refs != self.reference_values:
+            self._hoomd_forcefield = self._create_hoomd_forcefield()
         return self._hoomd_forcefield
 
     @property
@@ -283,6 +290,7 @@ class System(ABC):
         )
         for force in ff:
             force_list.extend(ff[force])
+        self._ff_refs = self._reference_values.copy()
         return force_list
 
     def _create_hoomd_snapshot(self):
@@ -293,6 +301,7 @@ class System(ABC):
             if self._reference_values
             else None,
         )
+        self._snap_refs = self._reference_values.copy()
         return snap
 
     def _apply_forcefield(self):

--- a/hoomd_organics/tests/base/test_system.py
+++ b/hoomd_organics/tests/base/test_system.py
@@ -266,6 +266,28 @@ class TestSystem(BaseTest):
             system.reference_energy.to("kcal/mol").value, 0.066, atol=1e-3
         )
 
+    def test_rebuild_snapshot(self, polyethylene):
+        polyethylene = polyethylene(lengths=5, num_mols=1)
+        system = Pack(
+            molecules=[polyethylene],
+            force_field=[OPLS_AA()],
+            density=1.0,
+            r_cut=2.5,
+            auto_scale=False,
+        )
+        assert system._snap_refs == system.reference_values
+        assert system._ff_refs == system.reference_values
+        init_snap = system.hoomd_snapshot
+        new_snap = system.hoomd_snapshot
+        assert init_snap == new_snap
+        system.reference_length = 1 * u.angstrom
+        system.reference_energy = 1 * u.kcal / u.mol
+        system.reference_mass = 1 * u.amu
+        assert system._snap_refs != system.reference_values
+        assert system._ff_refs != system.reference_values
+        new_snap = system.hoomd_snapshot
+        assert init_snap != new_snap
+
     def test_ref_values_no_autoscale(self, polyethylene):
         polyethylene = polyethylene(lengths=5, num_mols=1)
         system = Pack(

--- a/hoomd_organics/tests/base/test_system.py
+++ b/hoomd_organics/tests/base/test_system.py
@@ -234,7 +234,7 @@ class TestSystem(BaseTest):
         )
 
         assert np.allclose(
-            system.reference_length.to("angstrom").value, 3.39966951, atol=1e-3
+            system.reference_length.to("angstrom").value, 3.5, atol=1e-3
         )
         reduced_box = system.hoomd_snapshot.configuration.box[0:3]
         calc_box = reduced_box * system.reference_length.to("nm").value

--- a/hoomd_organics/tests/base/test_system.py
+++ b/hoomd_organics/tests/base/test_system.py
@@ -227,7 +227,7 @@ class TestSystem(BaseTest):
         polyethylene = polyethylene(lengths=5, num_mols=5)
         system = Pack(
             molecules=[polyethylene],
-            force_field=[GAFF()],
+            force_field=[OPLS_AA()],
             density=1.0,
             r_cut=2.5,
             auto_scale=True,
@@ -246,7 +246,7 @@ class TestSystem(BaseTest):
         polyethylene = polyethylene(lengths=5, num_mols=5)
         system = Pack(
             molecules=[polyethylene],
-            force_field=[GAFF()],
+            force_field=[OPLS_AA()],
             density=1.0,
             r_cut=2.5,
             auto_scale=True,
@@ -262,13 +262,13 @@ class TestSystem(BaseTest):
         polyethylene = polyethylene(lengths=5, num_mols=5)
         system = Pack(
             molecules=[polyethylene],
-            force_field=[GAFF()],
+            force_field=[OPLS_AA()],
             density=1.0,
             r_cut=2.5,
             auto_scale=True,
         )
         assert np.allclose(
-            system.reference_energy.to("kcal/mol").value, 0.1094, atol=1e-3
+            system.reference_energy.to("kcal/mol").value, 0.066, atol=1e-3
         )
 
     def test_ref_values_no_autoscale(self, polyethylene):

--- a/hoomd_organics/tests/base/test_system.py
+++ b/hoomd_organics/tests/base/test_system.py
@@ -6,12 +6,7 @@ import unyt as u
 from unyt import Unit
 
 from hoomd_organics import Lattice, Pack
-from hoomd_organics.library import (
-    GAFF,
-    OPLS_AA,
-    OPLS_AA_DIMETHYLETHER,
-    OPLS_AA_PPS,
-)
+from hoomd_organics.library import OPLS_AA, OPLS_AA_DIMETHYLETHER, OPLS_AA_PPS
 from hoomd_organics.tests import BaseTest
 from hoomd_organics.utils.exceptions import ReferenceUnitError
 


### PR DESCRIPTION
This PR makes it so that both `_create_hoomd_forcefield` and `_create_hoomd_snapshot` are only ever called once, and that the properties for both `hoomd_snapshot` and `hoomd_forcefield` can be used without having to re-run any gmso process.

We've gone back and forth and how to do this @marjanAlbouye so let me know if you think we're creating other issues by doing this...