### PR TITLE
Refactor apply_forcefield

### DIFF
--- a/hoomd_organics/base/system.py
+++ b/hoomd_organics/base/system.py
@@ -53,7 +53,6 @@ class System(ABC):
         self._reference_values = base_units
         self._hoomd_snapshot = None
         self._hoomd_forcefield = []
-        self.r_cut = None
         self._gmso_forcefields_dict = dict()
         self._target_box = None
         # Reference values used when last writing snapshot and forcefields
@@ -271,11 +270,11 @@ class System(ABC):
         topology.identify_connections()
         return topology
 
-    def _create_hoomd_forcefield(self, nlist_buffer, pppm_kwargs):
+    def _create_hoomd_forcefield(self, r_cut, nlist_buffer, pppm_kwargs):
         force_list = []
         ff, refs = to_hoomd_forcefield(
             top=self.gmso_system,
-            r_cut=self.r_cut,
+            r_cut=r_cut,
             nlist_buffer=nlist_buffer,
             pppm_kwargs=pppm_kwargs,
             auto_scale=self.auto_scale,
@@ -352,7 +351,7 @@ class System(ABC):
 
         pppm_kwargs = {"resolution": pppm_resolution, "order": pppm_order}
         self._hoomd_forcefield = self._create_hoomd_forcefield(
-            nlist_buffer=nlist_buffer, pppm_kwargs=pppm_kwargs
+            r_cut=r_cut, nlist_buffer=nlist_buffer, pppm_kwargs=pppm_kwargs
         )
         self._hoomd_snapshot = self._create_hoomd_snapshot()
 
@@ -452,12 +451,8 @@ class Pack(System):
         self,
         molecules,
         density: float,
-        r_cut: float,
         force_field=None,
         auto_scale=False,
-        remove_hydrogens=False,
-        remove_charges=False,
-        scale_charges=False,
         base_units=dict(),
         packing_expand_factor=5,
         edge=0.2,
@@ -468,11 +463,7 @@ class Pack(System):
             molecules=molecules,
             density=density,
             force_field=force_field,
-            r_cut=r_cut,
             auto_scale=auto_scale,
-            remove_hydrogens=remove_hydrogens,
-            remove_charges=remove_charges,
-            scale_charges=scale_charges,
             base_units=base_units,
         )
 

--- a/hoomd_organics/base/system.py
+++ b/hoomd_organics/base/system.py
@@ -50,6 +50,7 @@ class System(ABC):
         self.density = density
         self.auto_scale = auto_scale
         self.all_molecules = []
+        self.gmso_system = None
         self._reference_values = base_units
         self._hoomd_snapshot = None
         self._hoomd_forcefield = []
@@ -58,7 +59,7 @@ class System(ABC):
         # Reference values used when last writing snapshot and forcefields
         self._ff_refs = dict()
         self._snap_refs = dict()
-        self.gmso_system = None
+        self._ff_kwargs = dict()
 
         # Collecting all molecules
         self.n_mol_types = 0
@@ -198,8 +199,10 @@ class System(ABC):
 
     @property
     def hoomd_forcefield(self):
-        if self._ff_refs != self.reference_values and self._force_field:
-            self._hoomd_forcefield = self._create_hoomd_forcefield()
+        if self._ff_refs != self.reference_values:
+            self._hoomd_forcefield = self._create_hoomd_forcefield(
+                **self._ff_kwargs
+            )
         return self._hoomd_forcefield
 
     @property
@@ -350,6 +353,11 @@ class System(ABC):
             self.remove_hydrogens()
 
         pppm_kwargs = {"resolution": pppm_resolution, "order": pppm_order}
+        self._ff_kwargs = {
+            "r_cut": r_cut,
+            "nlist_buffer": nlist_buffer,
+            "pppm_kwargs": pppm_kwargs,
+        }
         self._hoomd_forcefield = self._create_hoomd_forcefield(
             r_cut=r_cut, nlist_buffer=nlist_buffer, pppm_kwargs=pppm_kwargs
         )

--- a/hoomd_organics/base/system.py
+++ b/hoomd_organics/base/system.py
@@ -199,7 +199,7 @@ class System(ABC):
 
     @property
     def hoomd_forcefield(self):
-        if self._ff_refs != self.reference_values:
+        if self._ff_refs != self.reference_values and self._force_field:
             self._hoomd_forcefield = self._create_hoomd_forcefield(
                 **self._ff_kwargs
             )

--- a/hoomd_organics/base/system.py
+++ b/hoomd_organics/base/system.py
@@ -499,16 +499,12 @@ class Lattice(System):
         self,
         molecules,
         density: float,
-        r_cut: float,
         x: float,
         y: float,
         n: int,
         basis_vector=[0.5, 0.5, 0],
         force_field=None,
         auto_scale=False,
-        remove_hydrogens=False,
-        remove_charges=False,
-        scale_charges=False,
         base_units=dict(),
     ):
         self.x = x
@@ -519,11 +515,7 @@ class Lattice(System):
             molecules=molecules,
             density=density,
             force_field=force_field,
-            r_cut=r_cut,
             auto_scale=auto_scale,
-            remove_hydrogens=remove_hydrogens,
-            remove_charges=remove_charges,
-            scale_charges=scale_charges,
             base_units=base_units,
         )
 

--- a/hoomd_organics/tests/base/test_simulation.py
+++ b/hoomd_organics/tests/base/test_simulation.py
@@ -151,11 +151,11 @@ class TestSimulate(BaseTest):
     def test_update_volume_density(self, benzene_system):
         sim = Simulation.from_system(benzene_system)
         sim.run_update_volume(
-            kT=1.0, tau_kt=0.01, n_steps=500, period=1, final_density=0.1
+            kT=1.0, tau_kt=0.01, n_steps=500, period=1, final_density=0.05
         )
         assert np.isclose(
             sim.density.to(u.g / u.cm**3).value,
-            (0.1 * (u.g / u.cm**3)).value,
+            (0.05 * (u.g / u.cm**3)).value,
             atol=1e-4,
         )
 

--- a/hoomd_organics/tests/base/test_system.py
+++ b/hoomd_organics/tests/base/test_system.py
@@ -644,6 +644,33 @@ class TestSystem(BaseTest):
         with pytest.raises(ReferenceUnitError):
             system.reference_mass = "1.0 m"
 
+    def test_apply_forcefield_no_forcefield(self, polyethylene):
+        polyethylene = polyethylene(lengths=5, num_mols=1)
+        system = Pack(
+            molecules=[polyethylene],
+            force_field=None,
+            density=1.0,
+            auto_scale=False,
+        )
+        with pytest.raises(ValueError):
+            system.apply_forcefield(r_cut=2.5)
+
+    def test_forcefield_kwargs_attr(self, polyethylene):
+        polyethylene = polyethylene(lengths=5, num_mols=1)
+        system = Pack(
+            molecules=[polyethylene],
+            force_field=[OPLS_AA()],
+            density=1.0,
+            auto_scale=False,
+        )
+        system.apply_forcefield(
+            r_cut=2.5, nlist_buffer=0.5, pppm_resolution=(4, 4, 4), pppm_order=3
+        )
+        assert system._ff_kwargs["r_cut"] == 2.5
+        assert system._ff_kwargs["nlist_buffer"] == 0.5
+        assert system._ff_kwargs["pppm_kwargs"]["resolution"] == (4, 4, 4)
+        assert system._ff_kwargs["pppm_kwargs"]["order"] == 3
+
     def test_lattice_polymer(self, polyethylene):
         polyethylene = polyethylene(lengths=2, num_mols=32)
         system = Lattice(

--- a/hoomd_organics/tests/base/test_system.py
+++ b/hoomd_organics/tests/base/test_system.py
@@ -144,7 +144,7 @@ class TestSystem(BaseTest):
                     mass=1.008 * Unit("amu"),
                 )
 
-        system._remove_hydrogens()
+        system.remove_hydrogens()
         assert system.gmso_system.n_sites == 6
 
     def test_remove_hydrogen_no_hydrogen(self, benzene_molecule):
@@ -165,7 +165,7 @@ class TestSystem(BaseTest):
             system.gmso_system.remove_site(h_site)
 
         with pytest.warns():
-            system._remove_hydrogens()
+            system.remove_hydrogens()
 
     def test_add_mass_charges(self, benzene_molecule):
         benzene_mols = benzene_molecule(n_mols=1)
@@ -211,7 +211,7 @@ class TestSystem(BaseTest):
 
     def test_mass(self, pps_molecule):
         pps_mol = pps_molecule(n_mols=20)
-        system = Pack(molecules=[pps_mol], density=1.0, r_cut=2.5)
+        system = Pack(molecules=[pps_mol], density=1.0)
         assert np.allclose(
             system.mass, ((12.011 * 6) + (1.008 * 6) + 32.06) * 20, atol=1e-4
         )
@@ -257,7 +257,6 @@ class TestSystem(BaseTest):
             molecules=[polyethylene],
             force_field=[OPLS_AA()],
             density=1.0,
-            r_cut=2.5,
             auto_scale=True,
         )
         system.apply_forcefield(r_cut=2.5)

--- a/hoomd_organics/tests/base/test_system.py
+++ b/hoomd_organics/tests/base/test_system.py
@@ -17,10 +17,10 @@ class TestSystem(BaseTest):
         system = Pack(
             molecules=[benzene_mols],
             density=0.8,
-            r_cut=2.5,
             force_field=OPLS_AA(),
             auto_scale=True,
         )
+        system.apply_forcefield(r_cut=2.5)
         assert system.n_mol_types == 1
         assert len(system.all_molecules) == len(benzene_mols.molecules)
         assert system.gmso_system.is_typed()
@@ -35,10 +35,10 @@ class TestSystem(BaseTest):
         system = Pack(
             molecules=[benzene_mol, ethane_mol],
             density=0.8,
-            r_cut=2.5,
             force_field=OPLS_AA(),
             auto_scale=True,
         )
+        system.apply_forcefield(r_cut=2.5)
         assert system.n_mol_types == 2
         assert len(system.all_molecules) == len(benzene_mol.molecules) + len(
             ethane_mol.molecules
@@ -63,10 +63,10 @@ class TestSystem(BaseTest):
         system = Pack(
             molecules=[dimethylether_mol, pps_mol],
             density=0.8,
-            r_cut=2.5,
             force_field=[OPLS_AA_DIMETHYLETHER(), OPLS_AA_PPS()],
             auto_scale=True,
         )
+        system.apply_forcefield(r_cut=2.5)
         assert system.n_mol_types == 2
         assert len(system.all_molecules) == len(
             dimethylether_mol.molecules
@@ -95,10 +95,10 @@ class TestSystem(BaseTest):
         system = Pack(
             molecules=[benzene_mol],
             density=0.8,
-            r_cut=2.5,
             force_field=OPLS_AA(),
             auto_scale=True,
         )
+        system.apply_forcefield(r_cut=2.5)
         assert system.gmso_system.is_typed()
         assert len(system.hoomd_forcefield) > 0
         assert system.n_particles == system.hoomd_snapshot.particles.N
@@ -108,11 +108,10 @@ class TestSystem(BaseTest):
         system = Pack(
             molecules=[benzene_mol],
             density=0.8,
-            r_cut=2.5,
             force_field=OPLS_AA(),
             auto_scale=True,
-            remove_hydrogens=True,
         )
+        system.apply_forcefield(r_cut=2.5, remove_hydrogens=True)
         assert not any(
             [s.element.atomic_number == 1 for s in system.gmso_system.sites]
         )
@@ -132,11 +131,10 @@ class TestSystem(BaseTest):
         system = Pack(
             molecules=[benzene_mol],
             density=0.8,
-            r_cut=2.5,
             force_field=OPLS_AA(),
             auto_scale=True,
-            remove_hydrogens=False,
         )
+        system.apply_forcefield(r_cut=2.5, remove_hydrogens=False)
         for site in system.gmso_system.sites:
             if site.name == "H":
                 site.element = gmso.core.element.Element(
@@ -154,11 +152,10 @@ class TestSystem(BaseTest):
         system = Pack(
             molecules=[benzene_mol],
             density=0.8,
-            r_cut=2.5,
             force_field=OPLS_AA(),
             auto_scale=True,
-            remove_hydrogens=False,
         )
+        system.apply_forcefield(r_cut=2.5, remove_hydrogens=False)
         hydrogens = [
             site
             for site in system.gmso_system.sites
@@ -175,11 +172,11 @@ class TestSystem(BaseTest):
         system = Pack(
             molecules=[benzene_mols],
             density=0.8,
-            r_cut=2.5,
             force_field=OPLS_AA(),
             auto_scale=False,
-            remove_hydrogens=True,
-            scale_charges=False,
+        )
+        system.apply_forcefield(
+            r_cut=2.5, remove_hydrogens=True, scale_charges=False
         )
         for site in system.gmso_system.sites:
             assert site.mass.value == (12.011 + 1.008)
@@ -196,17 +193,18 @@ class TestSystem(BaseTest):
         low_density_system = Pack(
             molecules=[benzene_mol],
             density=0.1,
-            r_cut=2.5,
             force_field=OPLS_AA(),
             auto_scale=True,
         )
+        low_density_system.apply_forcefield(r_cut=2.5)
+
         high_density_system = Pack(
             molecules=[benzene_mol],
             density=0.9,
-            r_cut=2.5,
             force_field=OPLS_AA(),
             auto_scale=True,
         )
+        high_density_system.apply_forcefield(r_cut=2.5)
         assert all(
             low_density_system.target_box > high_density_system.target_box
         )
@@ -224,9 +222,9 @@ class TestSystem(BaseTest):
             molecules=[polyethylene],
             force_field=[OPLS_AA()],
             density=1.0,
-            r_cut=2.5,
             auto_scale=True,
         )
+        system.apply_forcefield(r_cut=2.5)
 
         assert np.allclose(
             system.reference_length.to("angstrom").value, 3.5, atol=1e-3
@@ -243,9 +241,9 @@ class TestSystem(BaseTest):
             molecules=[polyethylene],
             force_field=[OPLS_AA()],
             density=1.0,
-            r_cut=2.5,
             auto_scale=True,
         )
+        system.apply_forcefield(r_cut=2.5)
         total_red_mass = sum(system.hoomd_snapshot.particles.mass)
         assert np.allclose(
             system.mass,
@@ -262,6 +260,7 @@ class TestSystem(BaseTest):
             r_cut=2.5,
             auto_scale=True,
         )
+        system.apply_forcefield(r_cut=2.5)
         assert np.allclose(
             system.reference_energy.to("kcal/mol").value, 0.066, atol=1e-3
         )
@@ -272,9 +271,9 @@ class TestSystem(BaseTest):
             molecules=[polyethylene],
             force_field=[OPLS_AA()],
             density=1.0,
-            r_cut=2.5,
             auto_scale=False,
         )
+        system.apply_forcefield(r_cut=2.5)
         assert system._snap_refs == system.reference_values
         assert system._ff_refs == system.reference_values
         init_snap = system.hoomd_snapshot
@@ -294,9 +293,9 @@ class TestSystem(BaseTest):
             molecules=[polyethylene],
             force_field=[OPLS_AA()],
             density=1.0,
-            r_cut=2.5,
             auto_scale=False,
         )
+        system.apply_forcefield(r_cut=2.5)
         system.reference_length = 1 * u.angstrom
         system.reference_energy = 1 * u.kcal / u.mol
         system.reference_mass = 1 * u.amu
@@ -316,9 +315,9 @@ class TestSystem(BaseTest):
             molecules=[polyethylene],
             force_field=[OPLS_AA()],
             density=1.0,
-            r_cut=2.5,
             auto_scale=False,
         )
+        system.apply_forcefield(r_cut=2.5)
         ref_value_dict = {
             "length": 1 * u.angstrom,
             "energy": 3.0 * u.kcal / u.mol,
@@ -335,9 +334,9 @@ class TestSystem(BaseTest):
             molecules=[polyethylene],
             force_field=[OPLS_AA()],
             density=1.0,
-            r_cut=2.5,
             auto_scale=False,
         )
+        system.apply_forcefield(r_cut=2.5)
         ref_value_dict = {
             "length": "1 angstrom",
             "energy": "3 kcal/mol",
@@ -354,9 +353,9 @@ class TestSystem(BaseTest):
             molecules=[polyethylene],
             force_field=[OPLS_AA()],
             density=1.0,
-            r_cut=2.5,
             auto_scale=False,
         )
+        system.apply_forcefield(r_cut=2.5)
         ref_value_dict = {
             "length": 1 * u.angstrom,
             "energy": 3.0 * u.kcal / u.mol,
@@ -370,9 +369,9 @@ class TestSystem(BaseTest):
             molecules=[polyethylene],
             force_field=[OPLS_AA()],
             density=1.0,
-            r_cut=2.5,
             auto_scale=False,
         )
+        system.apply_forcefield(r_cut=2.5)
         ref_value_dict = {
             "length": 1 * u.angstrom,
             "energy": 3.0 * u.kcal / u.mol,
@@ -387,9 +386,9 @@ class TestSystem(BaseTest):
             molecules=[polyethylene],
             force_field=[OPLS_AA()],
             density=1.0,
-            r_cut=2.5,
             auto_scale=False,
         )
+        system.apply_forcefield(r_cut=2.5)
         system.reference_length = 1 * u.angstrom
         assert system.reference_length == 1 * u.angstrom
 
@@ -399,9 +398,9 @@ class TestSystem(BaseTest):
             molecules=[polyethylene],
             force_field=[OPLS_AA()],
             density=1.0,
-            r_cut=2.5,
             auto_scale=False,
         )
+        system.apply_forcefield(r_cut=2.5)
         with pytest.raises(ReferenceUnitError):
             system.reference_length = 1.0
 
@@ -411,9 +410,9 @@ class TestSystem(BaseTest):
             molecules=[polyethylene],
             force_field=[OPLS_AA()],
             density=1.0,
-            r_cut=2.5,
             auto_scale=False,
         )
+        system.apply_forcefield(r_cut=2.5)
         system.reference_length = "1 angstrom"
         assert system.reference_length == 1 * u.angstrom
 
@@ -423,9 +422,9 @@ class TestSystem(BaseTest):
             molecules=[polyethylene],
             force_field=[OPLS_AA()],
             density=1.0,
-            r_cut=2.5,
             auto_scale=False,
         )
+        system.apply_forcefield(r_cut=2.5)
         with pytest.raises(ReferenceUnitError):
             system.reference_length = "1.0"
 
@@ -435,9 +434,9 @@ class TestSystem(BaseTest):
             molecules=[polyethylene],
             force_field=[OPLS_AA()],
             density=1.0,
-            r_cut=2.5,
             auto_scale=False,
         )
+        system.apply_forcefield(r_cut=2.5)
         with pytest.raises(ReferenceUnitError):
             system.reference_length = "1.0 invalid_unit"
 
@@ -447,9 +446,9 @@ class TestSystem(BaseTest):
             molecules=[polyethylene],
             force_field=[OPLS_AA()],
             density=1.0,
-            r_cut=2.5,
             auto_scale=False,
         )
+        system.apply_forcefield(r_cut=2.5)
         with pytest.raises(ReferenceUnitError):
             system.reference_length = 1.0 * u.g
 
@@ -459,9 +458,9 @@ class TestSystem(BaseTest):
             molecules=[polyethylene],
             force_field=[OPLS_AA()],
             density=1.0,
-            r_cut=2.5,
             auto_scale=False,
         )
+        system.apply_forcefield(r_cut=2.5)
         with pytest.raises(ReferenceUnitError):
             system.reference_length = "1.0 g"
 
@@ -471,9 +470,9 @@ class TestSystem(BaseTest):
             molecules=[polyethylene],
             force_field=[OPLS_AA()],
             density=1.0,
-            r_cut=2.5,
             auto_scale=False,
         )
+        system.apply_forcefield(r_cut=2.5)
         system.reference_energy = 1 * u.kcal / u.mol
         assert system.reference_energy == 1 * u.kcal / u.mol
 
@@ -483,9 +482,9 @@ class TestSystem(BaseTest):
             molecules=[polyethylene],
             force_field=[OPLS_AA()],
             density=1.0,
-            r_cut=2.5,
             auto_scale=False,
         )
+        system.apply_forcefield(r_cut=2.5)
         with pytest.raises(ReferenceUnitError):
             system.reference_energy = 1.0
 
@@ -495,9 +494,9 @@ class TestSystem(BaseTest):
             molecules=[polyethylene],
             force_field=[OPLS_AA()],
             density=1.0,
-            r_cut=2.5,
             auto_scale=False,
         )
+        system.apply_forcefield(r_cut=2.5)
         system.reference_energy = "1 kJ"
         assert system.reference_energy == 1 * u.kJ
 
@@ -507,9 +506,9 @@ class TestSystem(BaseTest):
             molecules=[polyethylene],
             force_field=[OPLS_AA()],
             density=1.0,
-            r_cut=2.5,
             auto_scale=False,
         )
+        system.apply_forcefield(r_cut=2.5)
         system.reference_energy = "1 kcal/mol"
         assert system.reference_energy == 1 * u.kcal / u.mol
 
@@ -519,9 +518,9 @@ class TestSystem(BaseTest):
             molecules=[polyethylene],
             force_field=[OPLS_AA()],
             density=1.0,
-            r_cut=2.5,
             auto_scale=False,
         )
+        system.apply_forcefield(r_cut=2.5)
         with pytest.raises(ReferenceUnitError):
             system.reference_energy = "1.0"
 
@@ -531,9 +530,9 @@ class TestSystem(BaseTest):
             molecules=[polyethylene],
             force_field=[OPLS_AA()],
             density=1.0,
-            r_cut=2.5,
             auto_scale=False,
         )
+        system.apply_forcefield(r_cut=2.5)
         with pytest.raises(ReferenceUnitError):
             system.reference_energy = "1.0 invalid_unit"
 
@@ -543,9 +542,9 @@ class TestSystem(BaseTest):
             molecules=[polyethylene],
             force_field=[OPLS_AA()],
             density=1.0,
-            r_cut=2.5,
             auto_scale=False,
         )
+        system.apply_forcefield(r_cut=2.5)
         with pytest.raises(ReferenceUnitError):
             system.reference_energy = 1.0 * u.g
 
@@ -555,9 +554,9 @@ class TestSystem(BaseTest):
             molecules=[polyethylene],
             force_field=[OPLS_AA()],
             density=1.0,
-            r_cut=2.5,
             auto_scale=False,
         )
+        system.apply_forcefield(r_cut=2.5)
         with pytest.raises(ReferenceUnitError):
             system.reference_energy = "1.0 m"
 
@@ -567,9 +566,9 @@ class TestSystem(BaseTest):
             molecules=[polyethylene],
             force_field=[OPLS_AA()],
             density=1.0,
-            r_cut=2.5,
             auto_scale=False,
         )
+        system.apply_forcefield(r_cut=2.5)
 
         system.reference_mass = 1.0 * u.amu
         assert system.reference_mass == 1.0 * u.amu
@@ -580,9 +579,9 @@ class TestSystem(BaseTest):
             molecules=[polyethylene],
             force_field=[OPLS_AA()],
             density=1.0,
-            r_cut=2.5,
             auto_scale=False,
         )
+        system.apply_forcefield(r_cut=2.5)
         with pytest.raises(ReferenceUnitError):
             system.reference_mass = 1.0
 
@@ -592,9 +591,9 @@ class TestSystem(BaseTest):
             molecules=[polyethylene],
             force_field=[OPLS_AA()],
             density=1.0,
-            r_cut=2.5,
             auto_scale=False,
         )
+        system.apply_forcefield(r_cut=2.5)
         system.reference_mass = "1 g"
         assert system.reference_mass == 1.0 * u.g
 
@@ -604,9 +603,9 @@ class TestSystem(BaseTest):
             molecules=[polyethylene],
             force_field=[OPLS_AA()],
             density=1.0,
-            r_cut=2.5,
             auto_scale=False,
         )
+        system.apply_forcefield(r_cut=2.5)
         with pytest.raises(ReferenceUnitError):
             system.reference_mass = "1.0"
 
@@ -616,9 +615,9 @@ class TestSystem(BaseTest):
             molecules=[polyethylene],
             force_field=[OPLS_AA()],
             density=1.0,
-            r_cut=2.5,
             auto_scale=False,
         )
+        system.apply_forcefield(r_cut=2.5)
         with pytest.raises(ReferenceUnitError):
             system.reference_mass = "1.0 invalid_unit"
 
@@ -628,9 +627,9 @@ class TestSystem(BaseTest):
             molecules=[polyethylene],
             force_field=[OPLS_AA()],
             density=1.0,
-            r_cut=2.5,
             auto_scale=False,
         )
+        system.apply_forcefield(r_cut=2.5)
         with pytest.raises(ReferenceUnitError):
             system.reference_energy = 1.0 * u.m
 
@@ -640,9 +639,9 @@ class TestSystem(BaseTest):
             molecules=[polyethylene],
             force_field=[OPLS_AA()],
             density=1.0,
-            r_cut=2.5,
             auto_scale=False,
         )
+        system.apply_forcefield(r_cut=2.5)
         with pytest.raises(ReferenceUnitError):
             system.reference_mass = "1.0 m"
 
@@ -652,12 +651,12 @@ class TestSystem(BaseTest):
             molecules=[polyethylene],
             force_field=[OPLS_AA()],
             density=1.0,
-            r_cut=2.5,
             x=1,
             y=1,
             n=4,
             auto_scale=True,
         )
+        system.apply_forcefield(r_cut=2.5)
 
         assert system.n_mol_types == 1
         assert len(system.all_molecules) == len(polyethylene.molecules)
@@ -672,12 +671,12 @@ class TestSystem(BaseTest):
             molecules=[benzene_mol],
             force_field=OPLS_AA(),
             density=1.0,
-            r_cut=2.5,
             x=1,
             y=1,
             n=4,
             auto_scale=True,
         )
+        system.apply_forcefield(r_cut=2.5)
         assert system.n_mol_types == 1
         assert len(system.all_molecules) == len(benzene_mol.molecules)
         assert len(system.hoomd_forcefield) > 0
@@ -689,19 +688,17 @@ class TestSystem(BaseTest):
         no_scale = Pack(
             molecules=pps_mol,
             density=0.5,
-            r_cut=2.4,
             force_field=OPLS_AA_PPS(),
             auto_scale=True,
-            scale_charges=False,
         )
+        no_scale.apply_forcefield(r_cut=2.5, scale_charges=False)
 
         with_scale = Pack(
             molecules=pps_mol,
             density=0.5,
-            r_cut=2.4,
             force_field=OPLS_AA_PPS(),
             auto_scale=True,
-            scale_charges=True,
         )
+        with_scale.apply_forcefield(r_cut=2.5, scale_charges=True)
         assert abs(no_scale.net_charge.value) > abs(with_scale.net_charge.value)
         assert np.allclose(0, with_scale.net_charge.value, atol=1e-30)

--- a/hoomd_organics/tests/base_test.py
+++ b/hoomd_organics/tests/base_test.py
@@ -217,10 +217,9 @@ class BaseTest:
         system = Pack(
             molecules=[benzene],
             density=0.2,
-            r_cut=2.5,
             force_field=OPLS_AA(),
-            auto_scale=True,
         )
+        system.apply_forcefield(r_cut=2.5, remove_hydrogens=True)
         return system
 
     @pytest.fixture()
@@ -230,7 +229,6 @@ class BaseTest:
         system = Pack(
             molecules=[benzene_mols],
             density=0.5,
-            r_cut=2.5,
             auto_scale=False,
         )
         return system
@@ -241,11 +239,10 @@ class BaseTest:
         system = Pack(
             molecules=polyethylene_mol,
             density=0.5,
-            r_cut=2.5,
             force_field=OPLS_AA(),
             auto_scale=True,
-            remove_hydrogens=True,
         )
+        system.apply_forcefield(r_cut=2.5, remove_hydrogens=True)
         return system
 
     @pytest.fixture()

--- a/hoomd_organics/tests/base_test.py
+++ b/hoomd_organics/tests/base_test.py
@@ -218,8 +218,9 @@ class BaseTest:
             molecules=[benzene],
             density=0.2,
             force_field=OPLS_AA(),
+            auto_scale=True,
         )
-        system.apply_forcefield(r_cut=2.5, remove_hydrogens=True)
+        system.apply_forcefield(r_cut=2.5, auto_scale=True)
         return system
 
     @pytest.fixture()

--- a/hoomd_organics/tests/library/test_tensile.py
+++ b/hoomd_organics/tests/library/test_tensile.py
@@ -17,6 +17,8 @@ class TestTensileSimulation(BaseTest):
             n=4,
             auto_scale=True,
         )
+        system.apply_forcefield(r_cut=2.5)
+
         tensile_sim = Tensile(
             initial_state=system.hoomd_snapshot,
             forcefield=system.hoomd_forcefield,

--- a/hoomd_organics/tests/library/test_tensile.py
+++ b/hoomd_organics/tests/library/test_tensile.py
@@ -12,7 +12,6 @@ class TestTensileSimulation(BaseTest):
             molecules=[pps],
             force_field=[OPLS_AA_PPS()],
             density=1.0,
-            r_cut=2.5,
             x=1.2,
             y=1.2,
             n=4,


### PR DESCRIPTION
This PR is related to #55 and a comment in there.  This opens up the `_apply_forcefield` and rather than it being called automatically inside of `System.__init__` is has to be called manually. The forcefield related parameters are moved out of `System.__init__` and into `apply_forcefield` and the PPPM arguments are added.

@marjanAlbouye and I have gone back and forth between thinking about how the `appy_forcefield` method should be handled, so let me know what you think and if you recognize any issues that might pop up from these changes.