### PR TITLE
Update apply_forcefield and molecule forcefield

### DIFF
--- a/hoomd_organics/base/__init__.py
+++ b/hoomd_organics/base/__init__.py
@@ -1,4 +1,5 @@
 """Base classes for hoomd_organics."""
+from .forcefield import BaseHOOMDForcefield, BaseXMLForcefield
 from .molecule import CoPolymer, Molecule, Polymer
 from .simulation import Simulation
 from .system import Lattice, Pack, System

--- a/hoomd_organics/base/forcefield.py
+++ b/hoomd_organics/base/forcefield.py
@@ -13,7 +13,9 @@ class BaseXMLForcefield(foyer.Forcefield):
             forcefield_files=forcefield_files, name=name
         )
         self.ff_type = FF_Types.XML
-        self.gmso_ff = ffutils.FoyerFFs().load(forcefield_files).to_gmso_ff()
+        self.gmso_ff = (
+            ffutils.FoyerFFs().load(forcefield_files or name).to_gmso_ff()
+        )
 
 
 class BaseHOOMDForcefield:

--- a/hoomd_organics/base/forcefield.py
+++ b/hoomd_organics/base/forcefield.py
@@ -1,0 +1,30 @@
+"""Base forcefield classes."""
+import forcefield_utilities as ffutils
+import foyer
+
+from hoomd_organics.utils import FF_Types
+
+
+class BaseXMLForcefield(foyer.Forcefield):
+    """Base XML forcefield class."""
+
+    def __init__(self, forcefield_files=None, name=None):
+        super(BaseXMLForcefield, self).__init__(
+            forcefield_files=forcefield_files, name=name
+        )
+        self.ff_type = FF_Types.XML
+        self.gmso_ff = ffutils.FoyerFFs().load(forcefield_files).to_gmso_ff()
+
+
+class BaseHOOMDForcefield:
+    """Base HOOMD forcefield class."""
+
+    def __init__(self, hoomd_forces):
+        self.ff_type = FF_Types.HOOMD
+        self.hoomd_forces = hoomd_forces
+        if hoomd_forces is None:
+            raise NotImplementedError(
+                "`hoomd_forces` must be defined in the subclass."
+            )
+        if not isinstance(hoomd_forces, list):
+            raise TypeError("`hoomd_forces` must be a list.")

--- a/hoomd_organics/base/forcefield.py
+++ b/hoomd_organics/base/forcefield.py
@@ -2,8 +2,6 @@
 import forcefield_utilities as ffutils
 import foyer
 
-from hoomd_organics.utils import FF_Types
-
 
 class BaseXMLForcefield(foyer.Forcefield):
     """Base XML forcefield class."""
@@ -12,7 +10,6 @@ class BaseXMLForcefield(foyer.Forcefield):
         super(BaseXMLForcefield, self).__init__(
             forcefield_files=forcefield_files, name=name
         )
-        self.ff_type = FF_Types.XML
         self.gmso_ff = (
             ffutils.FoyerFFs().load(forcefield_files or name).to_gmso_ff()
         )
@@ -22,7 +19,6 @@ class BaseHOOMDForcefield:
     """Base HOOMD forcefield class."""
 
     def __init__(self, hoomd_forces):
-        self.ff_type = FF_Types.HOOMD
         self.hoomd_forces = hoomd_forces
         if hoomd_forces is None:
             raise NotImplementedError(

--- a/hoomd_organics/base/molecule.py
+++ b/hoomd_organics/base/molecule.py
@@ -401,17 +401,6 @@ class Molecule:
         elif isinstance(self.force_field, List):
             _validate_hoomd_ff(self.force_field, self.topology_information)
 
-    def _assign_mol_name(self, name):
-        """Assign a name to the molecule."""
-        for mol in self.molecules:
-            mol.name = name
-            # TODO: This is a hack to make sure that the name of the children is
-            # also updated, so that when converting to gmso, all the sites have
-            # the correct name. This needs additional investigation into gmso's
-            # convert mbuilder to gmso functionality.
-            for child in mol.children:
-                child.name = name
-
 
 class Polymer(Molecule):
     """Builds a polymer from a monomer.

--- a/hoomd_organics/base/molecule.py
+++ b/hoomd_organics/base/molecule.py
@@ -7,17 +7,13 @@ from typing import List
 import mbuild as mb
 from gmso.core.topology import Topology
 from gmso.external.convert_mbuild import from_mbuild, to_mbuild
+from gmso.parameterization import apply
 from grits import CG_Compound
 from mbuild.lib.recipes import Polymer as mbPolymer
 
 from hoomd_organics.utils import check_return_iterable
-from hoomd_organics.utils.base_types import FF_Types
 from hoomd_organics.utils.exceptions import MoleculeLoadError
-from hoomd_organics.utils.ff_utils import (
-    _validate_hoomd_ff,
-    apply_xml_ff,
-    find_xml_ff,
-)
+from hoomd_organics.utils.ff_utils import _validate_hoomd_ff
 
 
 class Molecule:
@@ -32,11 +28,12 @@ class Molecule:
     ----------
     num_mols : int, required
         Number of molecules to generate.
-    force_field : str, default None
-        The force field to apply to the molecule.
-        Note that setting force_field will not apply the forcefield to the
-        molecule. The forcefield in this step is just used for validation
-        purposes.
+        force_field : hoomd_organics.ForceField or a list of ForceField objects,
+                default=None
+            The force field to be applied to the system for parameterization.
+            Note that setting `force_field` will not apply the forcefield to the
+            molecule. The forcefield in this step is just used for validation
+            purposes.
     smiles : str, default None
         The smiles string of the molecule to generate.
     file : str, default None
@@ -391,16 +388,18 @@ class Molecule:
 
     def _validate_force_field(self):
         """Validate the force field for the molecule."""
-        self.ff_type = None
-        if isinstance(self.force_field, str):
-            ff_xml_path, ff_type = find_xml_ff(self.force_field)
-            self.ff_type = ff_type
-            self.gmso_molecule = apply_xml_ff(ff_xml_path, self.gmso_molecule)
+        if hasattr(self.force_field, "gmso_ff"):
+            self.gmso_molecule = apply(
+                self.gmso_molecule,
+                self.force_field.gmso_ff,
+                identify_connections=True,
+                speedup_by_moltag=True,
+                speedup_by_molgraph=False,
+            )
             # Update topology information from typed gmso after applying ff.
             self._identify_topology_information(self.gmso_molecule)
         elif isinstance(self.force_field, List):
             _validate_hoomd_ff(self.force_field, self.topology_information)
-            self.ff_type = FF_Types.Hoomd
 
     def _assign_mol_name(self, name):
         """Assign a name to the molecule."""

--- a/hoomd_organics/base/molecule.py
+++ b/hoomd_organics/base/molecule.py
@@ -29,12 +29,12 @@ class Molecule:
     ----------
     num_mols : int, required
         Number of molecules to generate.
-        force_field : hoomd_organics.ForceField or a list of ForceField objects,
-                default=None
-            The force field to be applied to the system for parameterization.
-            Note that setting `force_field` will not apply the forcefield to the
-            molecule. The forcefield in this step is just used for validation
-            purposes.
+        force_field : hoomd_organics.ForceField or a list of
+                    `hoomd.md.force.Force` objects, default=None
+            The force field to be applied to the molecule for parameterization.
+            Note that setting `force_field` does not actually apply the
+            forcefield to the molecule. The forcefield in this step is mainly
+            used for validation purposes.
     smiles : str, default None
         The smiles string of the molecule to generate.
     file : str, default None

--- a/hoomd_organics/base/molecule.py
+++ b/hoomd_organics/base/molecule.py
@@ -11,7 +11,8 @@ from gmso.parameterization import apply
 from grits import CG_Compound
 from mbuild.lib.recipes import Polymer as mbPolymer
 
-from hoomd_organics.utils import FF_Types, check_return_iterable
+from hoomd_organics.base import BaseHOOMDForcefield, BaseXMLForcefield
+from hoomd_organics.utils import check_return_iterable
 from hoomd_organics.utils.exceptions import ForceFieldError, MoleculeLoadError
 from hoomd_organics.utils.ff_utils import _validate_hoomd_ff
 
@@ -388,40 +389,29 @@ class Molecule:
 
     def _validate_force_field(self):
         """Validate the force field for the molecule."""
-        if hasattr(self.force_field, "ff_type"):
-            if self.force_field.ff_type == FF_Types.XML and hasattr(
-                self.force_field, "gmso_ff"
-            ):
-                self.gmso_molecule = apply(
-                    self.gmso_molecule,
-                    self.force_field.gmso_ff,
-                    identify_connections=True,
-                    speedup_by_moltag=True,
-                    speedup_by_molgraph=False,
-                )
-                # Update topology information from typed gmso after applying ff.
-                self._identify_topology_information(self.gmso_molecule)
-            elif self.force_field.ff_type == FF_Types.HOOMD and hasattr(
-                self.force_field, "hoomd_forcefield"
-            ):
-                _validate_hoomd_ff(
-                    self.force_field.hoomd_forcefield, self.topology_information
-                )
-            else:
-                raise ForceFieldError(
-                    "Unsupported forcefield type. Please "
-                    "check forcefield classes from "
-                    "`hoomd_orgnaics.library.forcefields` "
-                    "for supported forcefields."
-                )
+        if isinstance(self.force_field, BaseXMLForcefield):
+            self.gmso_molecule = apply(
+                self.gmso_molecule,
+                self.force_field.gmso_ff,
+                identify_connections=True,
+                speedup_by_moltag=True,
+                speedup_by_molgraph=False,
+            )
+            # Update topology information from typed gmso after applying ff.
+            self._identify_topology_information(self.gmso_molecule)
+        elif isinstance(self.force_field, BaseHOOMDForcefield):
+            _validate_hoomd_ff(self.force_field, self.topology_information)
         elif isinstance(self.force_field, List):
             _validate_hoomd_ff(self.force_field, self.topology_information)
         else:
             raise ForceFieldError(
                 "Unsupported forcefield type. Forcefields "
-                "should be of type "
-                "`hoomd_organics.ForceField` or a list of"
-                " `hoomd.md.force.Force` objects."
+                "should be a subclass of "
+                "`hoomd_organics.base.forcefield.BaseXMLForcefield` or "
+                "`hoomd_organics.base.forcefield.BaseHOOMDForcefield` or a "
+                "list of `hoomd.md.force.Force` objects. \n"
+                "Please check `hoomd_organics.library.forcefields` for "
+                "examples of supported forcefields."
             )
 
 

--- a/hoomd_organics/base/molecule.py
+++ b/hoomd_organics/base/molecule.py
@@ -400,7 +400,9 @@ class Molecule:
             # Update topology information from typed gmso after applying ff.
             self._identify_topology_information(self.gmso_molecule)
         elif isinstance(self.force_field, BaseHOOMDForcefield):
-            _validate_hoomd_ff(self.force_field, self.topology_information)
+            _validate_hoomd_ff(
+                self.force_field.hoomd_forces, self.topology_information
+            )
         elif isinstance(self.force_field, List):
             _validate_hoomd_ff(self.force_field, self.topology_information)
         else:

--- a/hoomd_organics/base/system.py
+++ b/hoomd_organics/base/system.py
@@ -312,7 +312,10 @@ class System(ABC):
     @property
     def hoomd_forcefield(self):
         """List of HOOMD forces."""
-        if self._ff_refs != self.reference_values and self._force_field:
+        if (
+            self._ff_refs != self.reference_values
+            and self._gmso_forcefields_dict
+        ):
             self._hoomd_forcefield = self._create_hoomd_forcefield(
                 **self._ff_kwargs
             )
@@ -443,22 +446,8 @@ class System(ABC):
         return None
         # check if forcefield is xml based. return error if not
 
-    def _assign_particle_idx(self):
-        # system_particles = list(self.system.particles())
-        # # assign particle idx to each particles based on self._mol_type_idx in
-        # # batches of similar idx
-        #
-        # #TODO: This is a hacky way to assign particle idx. Need to find a
-        # # better way to assign names to
-        # for i, mol_idx in enumerate(self._mol_type_idx):
-        #     system_particles[i].name = str(mol_idx)
-        #     if system_particles[i].parent:
-        #         system_particles[i].parent.name = str(mol_idx)
-        #     if system_particles[i].root:
-        #         system_particles[i].root.name = str(mol_idx)
-        #         if system_particles[i].root.children:
-        #             for child in system_particles[i].root.children:
-        #                 child.name = str(mol_idx)
+    def _assign_site_mol_type_idx(self):
+        """Assign molecule type index to the gmso sites."""
         for i, site in enumerate(self.gmso_system.sites):
             site.group = str(self._mol_type_idx[i])
 
@@ -546,7 +535,7 @@ class System(ABC):
             # assign names to all the particles of system based on mol_type to
             # match the keys in self._gmso_forcefields_dict and  recreate the
             # gmso system object
-            self._assign_particle_idx()
+            self._assign_site_mol_type_idx()
             # self.gmso_system = self._convert_to_gmso()
         self.gmso_system = apply(
             self.gmso_system,

--- a/hoomd_organics/base/system.py
+++ b/hoomd_organics/base/system.py
@@ -433,6 +433,12 @@ class System(ABC):
         self._snap_refs = self._reference_values.copy()
         return snap
 
+    def _validate_forcefield(self, input_forcefield):
+        self._force_field = None
+        if input_forcefield:
+            self._force_field = check_return_iterable(input_forcefield)
+        # check if forcefield is xml based. return error if not
+
     def apply_forcefield(
         self,
         r_cut,
@@ -480,10 +486,13 @@ class System(ABC):
             Neighborlist buffer for simulation cell.
 
         """
-        self._force_field = None
-        if force_field:
-            self._force_field = check_return_iterable(force_field)
-        # Collecting all force-fields only if xml force-field is provided
+        # make sure forcefield is xml based
+        self._validate_forcefield(force_field)
+
+        # check if molecules already had ff in them. If yes, use that  or
+        # return error (can't have two ff per molecule)
+
+        # Collecting all force-fields into a dict
         if self._force_field:
             for i in range(self.n_mol_types):
                 if not self._gmso_forcefields_dict.get(str(i)):
@@ -659,7 +668,6 @@ class Pack(System):
         self,
         molecules,
         density: float,
-        force_field=None,
         base_units=dict(),
         packing_expand_factor=5,
         edge=0.2,
@@ -669,7 +677,6 @@ class Pack(System):
         super(Pack, self).__init__(
             molecules=molecules,
             density=density,
-            force_field=force_field,
             base_units=base_units,
         )
 
@@ -711,7 +718,6 @@ class Lattice(System):
         y: float,
         n: int,
         basis_vector=[0.5, 0.5, 0],
-        force_field=None,
         base_units=dict(),
     ):
         self.x = x
@@ -721,7 +727,6 @@ class Lattice(System):
         super(Lattice, self).__init__(
             molecules=molecules,
             density=density,
-            force_field=force_field,
             base_units=base_units,
         )
 

--- a/hoomd_organics/base/system.py
+++ b/hoomd_organics/base/system.py
@@ -91,13 +91,13 @@ class System(ABC):
 
         # Collecting all molecules
         self.n_mol_types = 0
-        self.mol_type_idx = []
+        self._mol_type_idx = []
         for mol_item in self._molecules:
             if isinstance(mol_item, Molecule):
                 # extend mol_type_idx by number of particles in mol_item with
                 # a list with n_mol-types as values
-                self.mol_type_idx.extend(
-                    [self.n_mol_types] * len(mol_item.n_particles)
+                self._mol_type_idx.extend(
+                    [self.n_mol_types] * mol_item.n_particles
                 )
                 self.all_molecules.extend(mol_item.molecules)
                 # if ff is provided in Molecule class
@@ -448,7 +448,9 @@ class System(ABC):
         # assign particle idx to each particles based on self._mol_type_idx in
         # batches of similar idx
         for i, mol_idx in enumerate(self._mol_type_idx):
-            system_particles[i].name = mol_idx
+            system_particles[i].name = str(mol_idx)
+            if system_particles[i].parent:
+                system_particles[i].parent.name = str(mol_idx)
 
     def apply_forcefield(
         self,
@@ -534,9 +536,8 @@ class System(ABC):
             # assign names to all the particles of system based on mol_type to
             # match the keys in self._gmso_forcefields_dict and  recreate the
             # gmso system object
-            self.gmso_system = self._convert_to_gmso(
-                self._assign_particle_idx()
-            )
+            self._assign_particle_idx()
+            self.gmso_system = self._convert_to_gmso()
         self.gmso_system = apply(
             self.gmso_system,
             self._gmso_forcefields_dict,

--- a/hoomd_organics/base/system.py
+++ b/hoomd_organics/base/system.py
@@ -444,13 +444,23 @@ class System(ABC):
         # check if forcefield is xml based. return error if not
 
     def _assign_particle_idx(self):
-        system_particles = list(self.system.particles())
-        # assign particle idx to each particles based on self._mol_type_idx in
-        # batches of similar idx
-        for i, mol_idx in enumerate(self._mol_type_idx):
-            system_particles[i].name = str(mol_idx)
-            if system_particles[i].parent:
-                system_particles[i].parent.name = str(mol_idx)
+        # system_particles = list(self.system.particles())
+        # # assign particle idx to each particles based on self._mol_type_idx in
+        # # batches of similar idx
+        #
+        # #TODO: This is a hacky way to assign particle idx. Need to find a
+        # # better way to assign names to
+        # for i, mol_idx in enumerate(self._mol_type_idx):
+        #     system_particles[i].name = str(mol_idx)
+        #     if system_particles[i].parent:
+        #         system_particles[i].parent.name = str(mol_idx)
+        #     if system_particles[i].root:
+        #         system_particles[i].root.name = str(mol_idx)
+        #         if system_particles[i].root.children:
+        #             for child in system_particles[i].root.children:
+        #                 child.name = str(mol_idx)
+        for i, site in enumerate(self.gmso_system.sites):
+            site.group = str(self._mol_type_idx[i])
 
     def apply_forcefield(
         self,
@@ -537,10 +547,11 @@ class System(ABC):
             # match the keys in self._gmso_forcefields_dict and  recreate the
             # gmso system object
             self._assign_particle_idx()
-            self.gmso_system = self._convert_to_gmso()
+            # self.gmso_system = self._convert_to_gmso()
         self.gmso_system = apply(
             self.gmso_system,
             self._gmso_forcefields_dict,
+            match_ff_by="group",
             identify_connections=True,
             speedup_by_moltag=True,
             speedup_by_molgraph=False,

--- a/hoomd_organics/base/system.py
+++ b/hoomd_organics/base/system.py
@@ -138,7 +138,7 @@ class System(ABC):
                     else:
                         # if there is only one ff for all molecule types
                         ff_index = 0
-                    if getattr(self._force_field[ff_index], "gmso_ff"):
+                    if hasattr(self._force_field[ff_index], "gmso_ff"):
                         self._gmso_forcefields_dict[str(i)] = self._force_field[
                             ff_index
                         ].gmso_ff
@@ -242,6 +242,12 @@ class System(ABC):
             example, unyt.unyt_quantity(1, "nm").
 
         """
+        if self.auto_scale:
+            warnings.warn(
+                "`auto_scale` was set to True for this system. "
+                "Setting reference length manually disables auto "
+                "scaling."
+            )
         validated_length = validate_ref_value(length, u.dimensions.length)
         self._reference_values["length"] = validated_length
 
@@ -259,6 +265,12 @@ class System(ABC):
             example, unyt.unyt_quantity(1, "kJ/mol").
 
         """
+        if self.auto_scale:
+            warnings.warn(
+                "`auto_scale` was set to True for this system. "
+                "Setting reference energy manually disables auto "
+                "scaling."
+            )
         validated_energy = validate_ref_value(energy, u.dimensions.energy)
         self._reference_values["energy"] = validated_energy
 
@@ -276,6 +288,12 @@ class System(ABC):
             example, unyt.unyt_quantity(1, "amu").
 
         """
+        if self.auto_scale:
+            warnings.warn(
+                "`auto_scale` was set to True for this system. "
+                "Setting reference mass manually disables auto "
+                "scaling."
+            )
         validated_mass = validate_ref_value(mass, u.dimensions.mass)
         self._reference_values["mass"] = validated_mass
 
@@ -292,6 +310,13 @@ class System(ABC):
             length, mass, and energy.
 
         """
+        if self.auto_scale:
+            warnings.warn(
+                "`auto_scale` was set to True for this system. "
+                "Setting reference values manually disables auto "
+                "scaling."
+            )
+
         ref_keys = ["length", "mass", "energy"]
         for k in ref_keys:
             if k not in ref_value_dict.keys():

--- a/hoomd_organics/base/system.py
+++ b/hoomd_organics/base/system.py
@@ -465,19 +465,20 @@ class System(ABC):
                 "once."
             )
 
-        if input_forcefield and not isinstance(
-            input_forcefield, (BaseHOOMDForcefield, BaseXMLForcefield)
-        ):
-            raise ForceFieldError(
-                "Forcefield must be an instance of either "
-                " `BaseHOOMDForcefield` or "
-                "`BaseXMLForcefield`. \n"
-                "Please check "
-                "`hoomd_organics.library.forcefields` for "
-                "examples of supported forcefields."
-            )
         if input_forcefield:
             _force_field = check_return_iterable(input_forcefield)
+            if not all(
+                isinstance(ff, (BaseHOOMDForcefield, BaseXMLForcefield))
+                for ff in _force_field
+            ):
+                raise ForceFieldError(
+                    "Forcefield must be an instance of either "
+                    " `BaseHOOMDForcefield` or "
+                    "`BaseXMLForcefield`. \n"
+                    "Please check "
+                    "`hoomd_organics.library.forcefields` for "
+                    "examples of supported forcefields."
+                )
             # Collecting all force-fields into a dict with mol_type index as key
             for i in range(self.n_mol_types):
                 if not self._gmso_forcefields_dict.get(str(i)):

--- a/hoomd_organics/library/__init__.py
+++ b/hoomd_organics/library/__init__.py
@@ -5,6 +5,8 @@ from .forcefields import (
     OPLS_AA_BENZENE,
     OPLS_AA_DIMETHYLETHER,
     OPLS_AA_PPS,
+    BaseHOOMDForcefield,
+    BaseXMLForcefield,
     BeadSpring,
     FF_from_file,
 )

--- a/hoomd_organics/library/forcefields.py
+++ b/hoomd_organics/library/forcefields.py
@@ -6,6 +6,7 @@ import foyer
 import hoomd
 
 from hoomd_organics.assets import FF_DIR
+from hoomd_organics.utils import FF_Types
 
 
 class GAFF(foyer.Forcefield):
@@ -18,6 +19,7 @@ class GAFF(foyer.Forcefield):
             "The XML file was obtained from the antefoyer package: "
             "https://github.com/rsdefever/antefoyer/tree/master/antefoyer"
         )
+        self.ff_type = FF_Types.XML
         self.gmso_ff = ffutils.FoyerFFs().load(forcefield_files).to_gmso_ff()
 
 
@@ -27,6 +29,7 @@ class OPLS_AA(foyer.Forcefield):
     def __init__(self, name="oplsaa"):
         super(OPLS_AA, self).__init__(name=name)
         self.description = "opls-aa forcefield found in the Foyer package."
+        self.ff_type = FF_Types.XML
         self.gmso_ff = ffutils.FoyerFFs().load(name).to_gmso_ff()
 
 
@@ -44,6 +47,7 @@ class OPLS_AA_PPS(foyer.Forcefield):
             "experimental PPS papers. The spring constant taken "
             "from the equivalent angle in GAFF."
         )
+        self.ff_type = FF_Types.XML
         self.gmso_ff = ffutils.FoyerFFs().load(forcefield_files).to_gmso_ff()
 
 
@@ -56,6 +60,7 @@ class OPLS_AA_BENZENE(foyer.Forcefield):
             "Based on hoomd_organics.forcefields.OPLS_AA. "
             "Trimmed down to include only benzene parameters."
         )
+        self.ff_type = FF_Types.XML
         self.gmso_ff = ffutils.FoyerFFs().load(forcefield_files).to_gmso_ff()
 
 
@@ -70,6 +75,7 @@ class OPLS_AA_DIMETHYLETHER(foyer.Forcefield):
             "Based on hoomd_organics.forcefields.OPLS_AA. "
             "Trimmed down to include only dimethyl ether parameters."
         )
+        self.ff_type = FF_Types.XML
         self.gmso_ff = ffutils.FoyerFFs().load(forcefield_files).to_gmso_ff()
 
 
@@ -78,6 +84,7 @@ class FF_from_file(foyer.Forcefield):
 
     def __init__(self, xml_file):
         super(FF_from_file, self).__init__(forcefield_files=xml_file)
+        self.ff_type = FF_Types.XML
         self.gmso_ff = ffutils.FoyerFFs().load(xml_file).to_gmso_ff()
 
 
@@ -147,6 +154,7 @@ class BeadSpring:
         self.r_cut = r_cut
         self.exclusions = exclusions
         self.hoomd_forcefield = self._create_forcefield()
+        self.ff_type = FF_Types.HOOMD
 
     def _create_forcefield(self):
         """Create the hoomd force objects."""

--- a/hoomd_organics/library/forcefields.py
+++ b/hoomd_organics/library/forcefields.py
@@ -1,12 +1,10 @@
 """All pre-defined forcefield classes for use in hoomd_organics."""
 import itertools
 
-import forcefield_utilities as ffutils
 import hoomd
 
 from hoomd_organics.assets import FF_DIR
 from hoomd_organics.base import BaseHOOMDForcefield, BaseXMLForcefield
-from hoomd_organics.utils import FF_Types
 
 
 class GAFF(BaseXMLForcefield):
@@ -67,8 +65,6 @@ class OPLS_AA_DIMETHYLETHER(BaseXMLForcefield):
             "Based on hoomd_organics.forcefields.OPLS_AA. "
             "Trimmed down to include only dimethyl ether parameters."
         )
-        self.ff_type = FF_Types.XML
-        self.gmso_ff = ffutils.FoyerFFs().load(forcefield_files).to_gmso_ff()
 
 
 class FF_from_file(BaseXMLForcefield):

--- a/hoomd_organics/library/forcefields.py
+++ b/hoomd_organics/library/forcefields.py
@@ -2,31 +2,11 @@
 import itertools
 
 import forcefield_utilities as ffutils
-import foyer
 import hoomd
 
 from hoomd_organics.assets import FF_DIR
+from hoomd_organics.base import BaseHOOMDForcefield, BaseXMLForcefield
 from hoomd_organics.utils import FF_Types
-
-
-class BaseXMLForcefield(foyer.Forcefield):
-    """Base XML forcefield class."""
-
-    def __init__(self, forcefield_files=None, name=None):
-        super(BaseXMLForcefield, self).__init__(
-            forcefield_files=forcefield_files, name=name
-        )
-        self.ff_type = FF_Types.XML
-        self.gmso_ff = ffutils.FoyerFFs().load(forcefield_files).to_gmso_ff()
-
-
-class BaseHOOMDForcefield:
-    """Base HOOMD forcefield class."""
-
-    def __init__(self, hoomd_forces=None):
-        super(BaseHOOMDForcefield, self).__init__()
-        self.hoomd_forces = hoomd_forces
-        self.ff_type = FF_Types.HOOMD
 
 
 class GAFF(BaseXMLForcefield):
@@ -164,7 +144,8 @@ class BeadSpring(BaseHOOMDForcefield):
         self.dihedrals = dihedrals
         self.r_cut = r_cut
         self.exclusions = exclusions
-        self.hoomd_forces = self._create_forcefield()
+        hoomd_forces = self._create_forcefield()
+        super(BeadSpring, self).__init__(hoomd_forces)
 
     def _create_forcefield(self):
         """Create the hoomd force objects."""

--- a/hoomd_organics/library/forcefields.py
+++ b/hoomd_organics/library/forcefields.py
@@ -20,6 +20,15 @@ class BaseXMLForcefield(foyer.Forcefield):
         self.gmso_ff = ffutils.FoyerFFs().load(forcefield_files).to_gmso_ff()
 
 
+class BaseHOOMDForcefield:
+    """Base HOOMD forcefield class."""
+
+    def __init__(self, hoomd_forces=None):
+        super(BaseHOOMDForcefield, self).__init__()
+        self.hoomd_forces = hoomd_forces
+        self.ff_type = FF_Types.HOOMD
+
+
 class GAFF(BaseXMLForcefield):
     """GAFF forcefield class."""
 
@@ -90,7 +99,7 @@ class FF_from_file(BaseXMLForcefield):
         self.description = "Forcefield loaded from an XML file. "
 
 
-class BeadSpring:
+class BeadSpring(BaseHOOMDForcefield):
     """Bead-spring forcefield class.
 
     Given a dictionary of bead types, this class creates a list
@@ -155,8 +164,7 @@ class BeadSpring:
         self.dihedrals = dihedrals
         self.r_cut = r_cut
         self.exclusions = exclusions
-        self.hoomd_forcefield = self._create_forcefield()
-        self.ff_type = FF_Types.HOOMD
+        self.hoomd_forces = self._create_forcefield()
 
     def _create_forcefield(self):
         """Create the hoomd force objects."""

--- a/hoomd_organics/library/forcefields.py
+++ b/hoomd_organics/library/forcefields.py
@@ -9,7 +9,18 @@ from hoomd_organics.assets import FF_DIR
 from hoomd_organics.utils import FF_Types
 
 
-class GAFF(foyer.Forcefield):
+class BaseXMLForcefield(foyer.Forcefield):
+    """Base XML forcefield class."""
+
+    def __init__(self, forcefield_files=None, name=None):
+        super(BaseXMLForcefield, self).__init__(
+            forcefield_files=forcefield_files, name=name
+        )
+        self.ff_type = FF_Types.XML
+        self.gmso_ff = ffutils.FoyerFFs().load(forcefield_files).to_gmso_ff()
+
+
+class GAFF(BaseXMLForcefield):
     """GAFF forcefield class."""
 
     def __init__(self, forcefield_files=f"{FF_DIR}/gaff.xml"):
@@ -19,21 +30,17 @@ class GAFF(foyer.Forcefield):
             "The XML file was obtained from the antefoyer package: "
             "https://github.com/rsdefever/antefoyer/tree/master/antefoyer"
         )
-        self.ff_type = FF_Types.XML
-        self.gmso_ff = ffutils.FoyerFFs().load(forcefield_files).to_gmso_ff()
 
 
-class OPLS_AA(foyer.Forcefield):
+class OPLS_AA(BaseXMLForcefield):
     """OPLS All Atom forcefield class."""
 
     def __init__(self, name="oplsaa"):
         super(OPLS_AA, self).__init__(name=name)
         self.description = "opls-aa forcefield found in the Foyer package."
-        self.ff_type = FF_Types.XML
-        self.gmso_ff = ffutils.FoyerFFs().load(name).to_gmso_ff()
 
 
-class OPLS_AA_PPS(foyer.Forcefield):
+class OPLS_AA_PPS(BaseXMLForcefield):
     """OPLS All Atom for PPS molecule forcefield class."""
 
     def __init__(self, forcefield_files=f"{FF_DIR}/pps_opls.xml"):
@@ -47,11 +54,9 @@ class OPLS_AA_PPS(foyer.Forcefield):
             "experimental PPS papers. The spring constant taken "
             "from the equivalent angle in GAFF."
         )
-        self.ff_type = FF_Types.XML
-        self.gmso_ff = ffutils.FoyerFFs().load(forcefield_files).to_gmso_ff()
 
 
-class OPLS_AA_BENZENE(foyer.Forcefield):
+class OPLS_AA_BENZENE(BaseXMLForcefield):
     """OPLS All Atom for benzene molecule forcefield class."""
 
     def __init__(self, forcefield_files=f"{FF_DIR}/benzene_opls.xml"):
@@ -60,11 +65,9 @@ class OPLS_AA_BENZENE(foyer.Forcefield):
             "Based on hoomd_organics.forcefields.OPLS_AA. "
             "Trimmed down to include only benzene parameters."
         )
-        self.ff_type = FF_Types.XML
-        self.gmso_ff = ffutils.FoyerFFs().load(forcefield_files).to_gmso_ff()
 
 
-class OPLS_AA_DIMETHYLETHER(foyer.Forcefield):
+class OPLS_AA_DIMETHYLETHER(BaseXMLForcefield):
     """OPLS All Atom for dimethyl ether molecule forcefield class."""
 
     def __init__(self, forcefield_files=f"{FF_DIR}/dimethylether_opls.xml"):
@@ -79,13 +82,12 @@ class OPLS_AA_DIMETHYLETHER(foyer.Forcefield):
         self.gmso_ff = ffutils.FoyerFFs().load(forcefield_files).to_gmso_ff()
 
 
-class FF_from_file(foyer.Forcefield):
+class FF_from_file(BaseXMLForcefield):
     """Forcefield class for loading a forcefield from an XML file."""
 
-    def __init__(self, xml_file):
-        super(FF_from_file, self).__init__(forcefield_files=xml_file)
-        self.ff_type = FF_Types.XML
-        self.gmso_ff = ffutils.FoyerFFs().load(xml_file).to_gmso_ff()
+    def __init__(self, forcefield_files):
+        super(FF_from_file, self).__init__(forcefield_files=forcefield_files)
+        self.description = "Forcefield loaded from an XML file. "
 
 
 class BeadSpring:

--- a/hoomd_organics/tests/base/test_forcefield.py
+++ b/hoomd_organics/tests/base/test_forcefield.py
@@ -1,0 +1,56 @@
+import pytest
+
+from hoomd_organics.base import BaseHOOMDForcefield, BaseXMLForcefield
+from hoomd_organics.tests import BaseTest
+from hoomd_organics.utils import FF_Types
+
+
+class TestBaseForcefield(BaseTest):
+    def test_base_xml_forcefield(self, benzene_xml):
+        base_xml_ff = BaseXMLForcefield(forcefield_files=benzene_xml)
+        assert base_xml_ff.gmso_ff is not None
+        assert base_xml_ff.ff_type == FF_Types.XML
+
+    def test_base_xml_forcefield_no_files(self):
+        with pytest.raises(TypeError):
+            BaseXMLForcefield(forcefield_files=None)
+
+    def test_base_xml_forcefield_name(self):
+        base_xml_ff = BaseXMLForcefield(name="oplsaa")
+        assert base_xml_ff.gmso_ff is not None
+        assert base_xml_ff.ff_type == FF_Types.XML
+
+    def test_base_xml_forcefield_invalid_name(self):
+        with pytest.raises(Exception):
+            BaseXMLForcefield(name="invalid_name")
+
+    def test_base_xml_forcefield_invalid_files(self):
+        with pytest.raises(Exception):
+            BaseXMLForcefield(forcefield_files="invalid_files")
+
+    def test_base_hoomd_forcefield(self):
+        class TestHOOMDFF(BaseHOOMDForcefield):
+            def __init__(self):
+                hoomd_forces = []
+                super().__init__(hoomd_forces=hoomd_forces)
+
+        test_hoomd_ff = TestHOOMDFF()
+        assert test_hoomd_ff.hoomd_forces == []
+        assert test_hoomd_ff.ff_type == FF_Types.HOOMD
+
+    def test_base_hoomd_forcefield_no_forces(self):
+        class TestHOOMDFF(BaseHOOMDForcefield):
+            def __init__(self):
+                super().__init__(hoomd_forces=None)
+
+        with pytest.raises(NotImplementedError):
+            TestHOOMDFF()
+
+    def test_base_hoomd_forcefield_invalid_forces_type(self):
+        class TestHOOMDFF(BaseHOOMDForcefield):
+            def __init__(self):
+                hoomd_forces = "invalid_type"
+                super().__init__(hoomd_forces=hoomd_forces)
+
+        with pytest.raises(TypeError):
+            TestHOOMDFF()

--- a/hoomd_organics/tests/base/test_forcefield.py
+++ b/hoomd_organics/tests/base/test_forcefield.py
@@ -2,14 +2,12 @@ import pytest
 
 from hoomd_organics.base import BaseHOOMDForcefield, BaseXMLForcefield
 from hoomd_organics.tests import BaseTest
-from hoomd_organics.utils import FF_Types
 
 
 class TestBaseForcefield(BaseTest):
     def test_base_xml_forcefield(self, benzene_xml):
         base_xml_ff = BaseXMLForcefield(forcefield_files=benzene_xml)
         assert base_xml_ff.gmso_ff is not None
-        assert base_xml_ff.ff_type == FF_Types.XML
 
     def test_base_xml_forcefield_no_files(self):
         with pytest.raises(TypeError):
@@ -18,7 +16,6 @@ class TestBaseForcefield(BaseTest):
     def test_base_xml_forcefield_name(self):
         base_xml_ff = BaseXMLForcefield(name="oplsaa")
         assert base_xml_ff.gmso_ff is not None
-        assert base_xml_ff.ff_type == FF_Types.XML
 
     def test_base_xml_forcefield_invalid_name(self):
         with pytest.raises(Exception):
@@ -36,7 +33,6 @@ class TestBaseForcefield(BaseTest):
 
         test_hoomd_ff = TestHOOMDFF()
         assert test_hoomd_ff.hoomd_forces == []
-        assert test_hoomd_ff.ff_type == FF_Types.HOOMD
 
     def test_base_hoomd_forcefield_no_forces(self):
         class TestHOOMDFF(BaseHOOMDForcefield):

--- a/hoomd_organics/tests/base/test_molecule.py
+++ b/hoomd_organics/tests/base/test_molecule.py
@@ -125,6 +125,14 @@ class TestMolecule(BaseTest):
                 compound=typed_molecule.gmso_molecule,
             )
 
+    def test_validate_force_field_invalid_ff_type(self, benzene_mb):
+        with pytest.raises(exceptions.ForceFieldError):
+            Molecule(
+                num_mols=2,
+                force_field="invalid_ff.xml",
+                compound=benzene_mb,
+            )
+
     def test_coarse_grain_with_single_beads(self, benzene_smiles):
         molecule = Molecule(num_mols=2, smiles=benzene_smiles)
         molecule.coarse_grain(beads={"A": benzene_smiles})

--- a/hoomd_organics/tests/base/test_molecule.py
+++ b/hoomd_organics/tests/base/test_molecule.py
@@ -3,7 +3,7 @@ import pytest
 from hoomd_organics import CoPolymer, Molecule, Polymer
 from hoomd_organics.library import OPLS_AA, BeadSpring, FF_from_file
 from hoomd_organics.tests import BaseTest
-from hoomd_organics.utils import FF_Types, exceptions
+from hoomd_organics.utils import exceptions
 
 
 class TestMolecule(BaseTest):
@@ -44,7 +44,6 @@ class TestMolecule(BaseTest):
         molecule = Molecule(
             num_mols=2, force_field=OPLS_AA(), compound=benzene_mb
         )
-        assert molecule.force_field.ff_type == FF_Types.XML
         assert molecule.gmso_molecule.is_typed()
         assert set(molecule.topology_information["particle_types"]) == {
             "opls_145",
@@ -58,7 +57,6 @@ class TestMolecule(BaseTest):
             force_field=FF_from_file(benzene_xml),
             compound=benzene_mb,
         )
-        assert molecule.force_field.ff_type == FF_Types.XML
         assert molecule.gmso_molecule.is_typed()
         assert set(molecule.topology_information["particle_types"]) == {
             "opls_145",

--- a/hoomd_organics/tests/base/test_molecule.py
+++ b/hoomd_organics/tests/base/test_molecule.py
@@ -1,7 +1,7 @@
 import pytest
 
 from hoomd_organics import CoPolymer, Molecule, Polymer
-from hoomd_organics.library import OPLS_AA, FF_from_file
+from hoomd_organics.library import OPLS_AA, BeadSpring, FF_from_file
 from hoomd_organics.tests import BaseTest
 from hoomd_organics.utils import FF_Types, exceptions
 
@@ -132,6 +132,23 @@ class TestMolecule(BaseTest):
                 force_field="invalid_ff.xml",
                 compound=benzene_mb,
             )
+
+    def test_validate_forcefield_hoomd_ff(self, benzene_smiles):
+        molecule = Molecule(num_mols=1, smiles=benzene_smiles)
+        molecule.coarse_grain(beads={"A": benzene_smiles})
+        beadspring_ff = BeadSpring(
+            r_cut=2.5,
+            beads={
+                "A": dict(epsilon=1.0, sigma=1.0),
+            },
+        )
+        cg_molecule = Molecule(
+            num_mols=1,
+            force_field=beadspring_ff,
+            compound=molecule.gmso_molecule,
+        )
+        assert cg_molecule.force_field == beadspring_ff
+        assert not molecule.gmso_molecule.is_typed()
 
     def test_coarse_grain_with_single_beads(self, benzene_smiles):
         molecule = Molecule(num_mols=2, smiles=benzene_smiles)

--- a/hoomd_organics/tests/base/test_system.py
+++ b/hoomd_organics/tests/base/test_system.py
@@ -8,7 +8,7 @@ from unyt import Unit
 from hoomd_organics import Lattice, Pack
 from hoomd_organics.library import OPLS_AA, OPLS_AA_DIMETHYLETHER, OPLS_AA_PPS
 from hoomd_organics.tests import BaseTest
-from hoomd_organics.utils.exceptions import ReferenceUnitError
+from hoomd_organics.utils.exceptions import ForceFieldError, ReferenceUnitError
 
 
 class TestSystem(BaseTest):
@@ -690,6 +690,24 @@ class TestSystem(BaseTest):
         assert system._ff_kwargs["nlist_buffer"] == 0.5
         assert system._ff_kwargs["pppm_kwargs"]["resolution"] == (4, 4, 4)
         assert system._ff_kwargs["pppm_kwargs"]["order"] == 3
+
+    def test_forcefield_list_hoomd_ff(self, polyethylene):
+        polyethylene = polyethylene(lengths=5, num_mols=1)
+        system = Pack(
+            molecules=[polyethylene],
+            force_field=[OPLS_AA()],
+            density=1.0,
+        )
+        system.apply_forcefield(r_cut=2.5, auto_scale=True)
+
+        hoomd_ff = system.hoomd_forcefield
+
+        with pytest.raises(ForceFieldError):
+            Pack(
+                molecules=[polyethylene],
+                force_field=hoomd_ff,
+                density=1.0,
+            )
 
     def test_lattice_polymer(self, polyethylene):
         polyethylene = polyethylene(lengths=2, num_mols=32)

--- a/hoomd_organics/tests/base/test_system.py
+++ b/hoomd_organics/tests/base/test_system.py
@@ -462,6 +462,17 @@ class TestSystem(BaseTest):
         with pytest.raises(ReferenceUnitError):
             system.reference_length = "1.0 g"
 
+    def test_ref_length_auto_scale_true(self, polyethylene):
+        polyethylene = polyethylene(lengths=5, num_mols=1)
+        system = Pack(
+            molecules=[polyethylene],
+            force_field=[OPLS_AA()],
+            density=1.0,
+        )
+        system.apply_forcefield(r_cut=2.5, auto_scale=True)
+        system.reference_length = 1 * u.angstrom
+        assert system.reference_length == 1 * u.angstrom
+
     def test_set_ref_energy(self, polyethylene):
         polyethylene = polyethylene(lengths=5, num_mols=1)
         system = Pack(
@@ -550,6 +561,17 @@ class TestSystem(BaseTest):
         with pytest.raises(ReferenceUnitError):
             system.reference_energy = "1.0 m"
 
+    def test_set_ref_energy_auto_scale_true(self, polyethylene):
+        polyethylene = polyethylene(lengths=5, num_mols=1)
+        system = Pack(
+            molecules=[polyethylene],
+            force_field=[OPLS_AA()],
+            density=1.0,
+        )
+        system.apply_forcefield(r_cut=2.5, auto_scale=True)
+        system.reference_energy = 1 * u.kcal / u.mol
+        assert system.reference_energy == 1 * u.kcal / u.mol
+
     def test_set_ref_mass(self, polyethylene):
         polyethylene = polyethylene(lengths=5, num_mols=1)
         system = Pack(
@@ -627,6 +649,18 @@ class TestSystem(BaseTest):
         system.apply_forcefield(r_cut=2.5, auto_scale=False)
         with pytest.raises(ReferenceUnitError):
             system.reference_mass = "1.0 m"
+
+    def test_set_ref_mass_auto_scale_true(self, polyethylene):
+        polyethylene = polyethylene(lengths=5, num_mols=1)
+        system = Pack(
+            molecules=[polyethylene],
+            force_field=[OPLS_AA()],
+            density=1.0,
+        )
+        system.apply_forcefield(r_cut=2.5, auto_scale=True)
+
+        system.reference_mass = 1.0 * u.amu
+        assert system.reference_mass == 1.0 * u.amu
 
     def test_apply_forcefield_no_forcefield(self, polyethylene):
         polyethylene = polyethylene(lengths=5, num_mols=1)

--- a/hoomd_organics/tests/base/test_system.py
+++ b/hoomd_organics/tests/base/test_system.py
@@ -698,7 +698,7 @@ class TestSystem(BaseTest):
             molecules=[polyethylene],
             density=1.0,
         )
-        with pytest.raises(ValueError):
+        with pytest.raises(ForceFieldError):
             system.apply_forcefield(
                 r_cut=2.5, force_field=None, auto_scale=False
             )

--- a/hoomd_organics/tests/base/test_system.py
+++ b/hoomd_organics/tests/base/test_system.py
@@ -18,9 +18,8 @@ class TestSystem(BaseTest):
             molecules=[benzene_mols],
             density=0.8,
             force_field=OPLS_AA(),
-            auto_scale=True,
         )
-        system.apply_forcefield(r_cut=2.5)
+        system.apply_forcefield(r_cut=2.5, auto_scale=True)
         assert system.n_mol_types == 1
         assert len(system.all_molecules) == len(benzene_mols.molecules)
         assert system.gmso_system.is_typed()
@@ -36,9 +35,8 @@ class TestSystem(BaseTest):
             molecules=[benzene_mol, ethane_mol],
             density=0.8,
             force_field=OPLS_AA(),
-            auto_scale=True,
         )
-        system.apply_forcefield(r_cut=2.5)
+        system.apply_forcefield(r_cut=2.5, auto_scale=True)
         assert system.n_mol_types == 2
         assert len(system.all_molecules) == len(benzene_mol.molecules) + len(
             ethane_mol.molecules
@@ -64,9 +62,8 @@ class TestSystem(BaseTest):
             molecules=[dimethylether_mol, pps_mol],
             density=0.8,
             force_field=[OPLS_AA_DIMETHYLETHER(), OPLS_AA_PPS()],
-            auto_scale=True,
         )
-        system.apply_forcefield(r_cut=2.5)
+        system.apply_forcefield(r_cut=2.5, auto_scale=True)
         assert system.n_mol_types == 2
         assert len(system.all_molecules) == len(
             dimethylether_mol.molecules
@@ -372,6 +369,22 @@ class TestSystem(BaseTest):
         with pytest.raises(ReferenceUnitError):
             system.reference_values = ref_value_dict
 
+    def test_set_ref_values_auto_scale_true(self, polyethylene):
+        polyethylene = polyethylene(lengths=5, num_mols=5)
+        system = Pack(
+            molecules=[polyethylene],
+            force_field=[OPLS_AA()],
+            density=1.0,
+        )
+        system.apply_forcefield(r_cut=2.5, auto_scale=True)
+        ref_value_dict = {
+            "length": 1 * u.angstrom,
+            "energy": 3.0 * u.kcal / u.mol,
+            "mass": 1.25 * u.Unit("amu"),
+        }
+        with pytest.warns():
+            system.reference_values = ref_value_dict
+
     def test_set_ref_length(self, polyethylene):
         polyethylene = polyethylene(lengths=5, num_mols=1)
         system = Pack(
@@ -389,9 +402,8 @@ class TestSystem(BaseTest):
             molecules=[polyethylene],
             force_field=[OPLS_AA()],
             density=1.0,
-            auto_scale=False,
         )
-        system.apply_forcefield(r_cut=2.5)
+        system.apply_forcefield(r_cut=2.5, auto_scale=False)
         with pytest.raises(ReferenceUnitError):
             system.reference_length = 1.0
 

--- a/hoomd_organics/tests/base/test_system.py
+++ b/hoomd_organics/tests/base/test_system.py
@@ -37,8 +37,8 @@ class TestSystem(BaseTest):
         assert len(system.all_molecules) == len(benzene_mol.molecules) + len(
             ethane_mol.molecules
         )
-        assert system.all_molecules[0].name == "0"
-        assert system.all_molecules[-1].name == "1"
+        assert system.gmso_system.sites[0].group == "0"
+        assert system.gmso_system.sites[-1].group == "1"
         assert system.gmso_system.is_typed()
         assert len(system.hoomd_forcefield) > 0
         assert system.n_particles == system.hoomd_snapshot.particles.N
@@ -64,8 +64,8 @@ class TestSystem(BaseTest):
         assert len(system.all_molecules) == len(
             dimethylether_mol.molecules
         ) + len(pps_mol.molecules)
-        assert system.all_molecules[0].name == "0"
-        assert system.all_molecules[-1].name == "1"
+        assert system.gmso_system.sites[0].group == "0"
+        assert system.gmso_system.sites[-1].group == "1"
         assert system.gmso_system.is_typed()
         assert len(system.hoomd_forcefield) > 0
         for hoomd_force in system.hoomd_forcefield:
@@ -129,6 +129,8 @@ class TestSystem(BaseTest):
             auto_scale=True,
         )
         for site in system.gmso_system.sites:
+            # this does not work as the name of all sites are changed to reflect
+            # the molecule type id
             if site.name == "H":
                 site.element = gmso.core.element.Element(
                     symbol="C",

--- a/hoomd_organics/tests/base/test_system.py
+++ b/hoomd_organics/tests/base/test_system.py
@@ -96,9 +96,8 @@ class TestSystem(BaseTest):
             molecules=[benzene_mol],
             density=0.8,
             force_field=OPLS_AA(),
-            auto_scale=True,
         )
-        system.apply_forcefield(r_cut=2.5)
+        system.apply_forcefield(r_cut=2.5, auto_scale=True)
         assert system.gmso_system.is_typed()
         assert len(system.hoomd_forcefield) > 0
         assert system.n_particles == system.hoomd_snapshot.particles.N
@@ -109,9 +108,12 @@ class TestSystem(BaseTest):
             molecules=[benzene_mol],
             density=0.8,
             force_field=OPLS_AA(),
+        )
+        system.apply_forcefield(
+            r_cut=2.5,
+            remove_hydrogens=True,
             auto_scale=True,
         )
-        system.apply_forcefield(r_cut=2.5, remove_hydrogens=True)
         assert not any(
             [s.element.atomic_number == 1 for s in system.gmso_system.sites]
         )
@@ -132,9 +134,10 @@ class TestSystem(BaseTest):
             molecules=[benzene_mol],
             density=0.8,
             force_field=OPLS_AA(),
-            auto_scale=True,
         )
-        system.apply_forcefield(r_cut=2.5, remove_hydrogens=False)
+        system.apply_forcefield(
+            r_cut=2.5, remove_hydrogens=False, auto_scale=True
+        )
         for site in system.gmso_system.sites:
             if site.name == "H":
                 site.element = gmso.core.element.Element(
@@ -153,9 +156,10 @@ class TestSystem(BaseTest):
             molecules=[benzene_mol],
             density=0.8,
             force_field=OPLS_AA(),
-            auto_scale=True,
         )
-        system.apply_forcefield(r_cut=2.5, remove_hydrogens=False)
+        system.apply_forcefield(
+            r_cut=2.5, remove_hydrogens=False, auto_scale=True
+        )
         hydrogens = [
             site
             for site in system.gmso_system.sites
@@ -173,10 +177,12 @@ class TestSystem(BaseTest):
             molecules=[benzene_mols],
             density=0.8,
             force_field=OPLS_AA(),
-            auto_scale=False,
         )
         system.apply_forcefield(
-            r_cut=2.5, remove_hydrogens=True, scale_charges=False
+            r_cut=2.5,
+            remove_hydrogens=True,
+            scale_charges=False,
+            auto_scale=False,
         )
         for site in system.gmso_system.sites:
             assert site.mass.value == (12.011 + 1.008)
@@ -194,17 +200,15 @@ class TestSystem(BaseTest):
             molecules=[benzene_mol],
             density=0.1,
             force_field=OPLS_AA(),
-            auto_scale=True,
         )
-        low_density_system.apply_forcefield(r_cut=2.5)
+        low_density_system.apply_forcefield(r_cut=2.5, auto_scale=True)
 
         high_density_system = Pack(
             molecules=[benzene_mol],
             density=0.9,
             force_field=OPLS_AA(),
-            auto_scale=True,
         )
-        high_density_system.apply_forcefield(r_cut=2.5)
+        high_density_system.apply_forcefield(r_cut=2.5, auto_scale=True)
         assert all(
             low_density_system.target_box > high_density_system.target_box
         )
@@ -222,9 +226,8 @@ class TestSystem(BaseTest):
             molecules=[polyethylene],
             force_field=[OPLS_AA()],
             density=1.0,
-            auto_scale=True,
         )
-        system.apply_forcefield(r_cut=2.5)
+        system.apply_forcefield(r_cut=2.5, auto_scale=True)
 
         assert np.allclose(
             system.reference_length.to("angstrom").value, 3.5, atol=1e-3
@@ -241,9 +244,8 @@ class TestSystem(BaseTest):
             molecules=[polyethylene],
             force_field=[OPLS_AA()],
             density=1.0,
-            auto_scale=True,
         )
-        system.apply_forcefield(r_cut=2.5)
+        system.apply_forcefield(r_cut=2.5, auto_scale=True)
         total_red_mass = sum(system.hoomd_snapshot.particles.mass)
         assert np.allclose(
             system.mass,
@@ -257,9 +259,8 @@ class TestSystem(BaseTest):
             molecules=[polyethylene],
             force_field=[OPLS_AA()],
             density=1.0,
-            auto_scale=True,
         )
-        system.apply_forcefield(r_cut=2.5)
+        system.apply_forcefield(r_cut=2.5, auto_scale=True)
         assert np.allclose(
             system.reference_energy.to("kcal/mol").value, 0.066, atol=1e-3
         )
@@ -270,9 +271,8 @@ class TestSystem(BaseTest):
             molecules=[polyethylene],
             force_field=[OPLS_AA()],
             density=1.0,
-            auto_scale=False,
         )
-        system.apply_forcefield(r_cut=2.5)
+        system.apply_forcefield(r_cut=2.5, auto_scale=False)
         assert system._snap_refs == system.reference_values
         assert system._ff_refs == system.reference_values
         init_snap = system.hoomd_snapshot
@@ -292,9 +292,8 @@ class TestSystem(BaseTest):
             molecules=[polyethylene],
             force_field=[OPLS_AA()],
             density=1.0,
-            auto_scale=False,
         )
-        system.apply_forcefield(r_cut=2.5)
+        system.apply_forcefield(r_cut=2.5, auto_scale=False)
         system.reference_length = 1 * u.angstrom
         system.reference_energy = 1 * u.kcal / u.mol
         system.reference_mass = 1 * u.amu
@@ -311,12 +310,9 @@ class TestSystem(BaseTest):
     def test_set_ref_values(self, polyethylene):
         polyethylene = polyethylene(lengths=5, num_mols=1)
         system = Pack(
-            molecules=[polyethylene],
-            force_field=[OPLS_AA()],
-            density=1.0,
-            auto_scale=False,
+            molecules=[polyethylene], force_field=[OPLS_AA()], density=1.0
         )
-        system.apply_forcefield(r_cut=2.5)
+        system.apply_forcefield(r_cut=2.5, auto_scale=False)
         ref_value_dict = {
             "length": 1 * u.angstrom,
             "energy": 3.0 * u.kcal / u.mol,
@@ -333,9 +329,8 @@ class TestSystem(BaseTest):
             molecules=[polyethylene],
             force_field=[OPLS_AA()],
             density=1.0,
-            auto_scale=False,
         )
-        system.apply_forcefield(r_cut=2.5)
+        system.apply_forcefield(r_cut=2.5, auto_scale=False)
         ref_value_dict = {
             "length": "1 angstrom",
             "energy": "3 kcal/mol",
@@ -352,9 +347,8 @@ class TestSystem(BaseTest):
             molecules=[polyethylene],
             force_field=[OPLS_AA()],
             density=1.0,
-            auto_scale=False,
         )
-        system.apply_forcefield(r_cut=2.5)
+        system.apply_forcefield(r_cut=2.5, auto_scale=False)
         ref_value_dict = {
             "length": 1 * u.angstrom,
             "energy": 3.0 * u.kcal / u.mol,
@@ -368,9 +362,8 @@ class TestSystem(BaseTest):
             molecules=[polyethylene],
             force_field=[OPLS_AA()],
             density=1.0,
-            auto_scale=False,
         )
-        system.apply_forcefield(r_cut=2.5)
+        system.apply_forcefield(r_cut=2.5, auto_scale=False)
         ref_value_dict = {
             "length": 1 * u.angstrom,
             "energy": 3.0 * u.kcal / u.mol,
@@ -385,9 +378,8 @@ class TestSystem(BaseTest):
             molecules=[polyethylene],
             force_field=[OPLS_AA()],
             density=1.0,
-            auto_scale=False,
         )
-        system.apply_forcefield(r_cut=2.5)
+        system.apply_forcefield(r_cut=2.5, auto_scale=False)
         system.reference_length = 1 * u.angstrom
         assert system.reference_length == 1 * u.angstrom
 
@@ -409,9 +401,8 @@ class TestSystem(BaseTest):
             molecules=[polyethylene],
             force_field=[OPLS_AA()],
             density=1.0,
-            auto_scale=False,
         )
-        system.apply_forcefield(r_cut=2.5)
+        system.apply_forcefield(r_cut=2.5, auto_scale=False)
         system.reference_length = "1 angstrom"
         assert system.reference_length == 1 * u.angstrom
 
@@ -421,9 +412,8 @@ class TestSystem(BaseTest):
             molecules=[polyethylene],
             force_field=[OPLS_AA()],
             density=1.0,
-            auto_scale=False,
         )
-        system.apply_forcefield(r_cut=2.5)
+        system.apply_forcefield(r_cut=2.5, auto_scale=False)
         with pytest.raises(ReferenceUnitError):
             system.reference_length = "1.0"
 
@@ -433,9 +423,8 @@ class TestSystem(BaseTest):
             molecules=[polyethylene],
             force_field=[OPLS_AA()],
             density=1.0,
-            auto_scale=False,
         )
-        system.apply_forcefield(r_cut=2.5)
+        system.apply_forcefield(r_cut=2.5, auto_scale=False)
         with pytest.raises(ReferenceUnitError):
             system.reference_length = "1.0 invalid_unit"
 
@@ -445,9 +434,8 @@ class TestSystem(BaseTest):
             molecules=[polyethylene],
             force_field=[OPLS_AA()],
             density=1.0,
-            auto_scale=False,
         )
-        system.apply_forcefield(r_cut=2.5)
+        system.apply_forcefield(r_cut=2.5, auto_scale=False)
         with pytest.raises(ReferenceUnitError):
             system.reference_length = 1.0 * u.g
 
@@ -457,9 +445,8 @@ class TestSystem(BaseTest):
             molecules=[polyethylene],
             force_field=[OPLS_AA()],
             density=1.0,
-            auto_scale=False,
         )
-        system.apply_forcefield(r_cut=2.5)
+        system.apply_forcefield(r_cut=2.5, auto_scale=False)
         with pytest.raises(ReferenceUnitError):
             system.reference_length = "1.0 g"
 
@@ -469,9 +456,8 @@ class TestSystem(BaseTest):
             molecules=[polyethylene],
             force_field=[OPLS_AA()],
             density=1.0,
-            auto_scale=False,
         )
-        system.apply_forcefield(r_cut=2.5)
+        system.apply_forcefield(r_cut=2.5, auto_scale=False)
         system.reference_energy = 1 * u.kcal / u.mol
         assert system.reference_energy == 1 * u.kcal / u.mol
 
@@ -481,9 +467,8 @@ class TestSystem(BaseTest):
             molecules=[polyethylene],
             force_field=[OPLS_AA()],
             density=1.0,
-            auto_scale=False,
         )
-        system.apply_forcefield(r_cut=2.5)
+        system.apply_forcefield(r_cut=2.5, auto_scale=False)
         with pytest.raises(ReferenceUnitError):
             system.reference_energy = 1.0
 
@@ -493,9 +478,8 @@ class TestSystem(BaseTest):
             molecules=[polyethylene],
             force_field=[OPLS_AA()],
             density=1.0,
-            auto_scale=False,
         )
-        system.apply_forcefield(r_cut=2.5)
+        system.apply_forcefield(r_cut=2.5, auto_scale=False)
         system.reference_energy = "1 kJ"
         assert system.reference_energy == 1 * u.kJ
 
@@ -505,9 +489,8 @@ class TestSystem(BaseTest):
             molecules=[polyethylene],
             force_field=[OPLS_AA()],
             density=1.0,
-            auto_scale=False,
         )
-        system.apply_forcefield(r_cut=2.5)
+        system.apply_forcefield(r_cut=2.5, auto_scale=False)
         system.reference_energy = "1 kcal/mol"
         assert system.reference_energy == 1 * u.kcal / u.mol
 
@@ -517,9 +500,8 @@ class TestSystem(BaseTest):
             molecules=[polyethylene],
             force_field=[OPLS_AA()],
             density=1.0,
-            auto_scale=False,
         )
-        system.apply_forcefield(r_cut=2.5)
+        system.apply_forcefield(r_cut=2.5, auto_scale=False)
         with pytest.raises(ReferenceUnitError):
             system.reference_energy = "1.0"
 
@@ -529,9 +511,8 @@ class TestSystem(BaseTest):
             molecules=[polyethylene],
             force_field=[OPLS_AA()],
             density=1.0,
-            auto_scale=False,
         )
-        system.apply_forcefield(r_cut=2.5)
+        system.apply_forcefield(r_cut=2.5, auto_scale=False)
         with pytest.raises(ReferenceUnitError):
             system.reference_energy = "1.0 invalid_unit"
 
@@ -541,9 +522,8 @@ class TestSystem(BaseTest):
             molecules=[polyethylene],
             force_field=[OPLS_AA()],
             density=1.0,
-            auto_scale=False,
         )
-        system.apply_forcefield(r_cut=2.5)
+        system.apply_forcefield(r_cut=2.5, auto_scale=False)
         with pytest.raises(ReferenceUnitError):
             system.reference_energy = 1.0 * u.g
 
@@ -553,9 +533,8 @@ class TestSystem(BaseTest):
             molecules=[polyethylene],
             force_field=[OPLS_AA()],
             density=1.0,
-            auto_scale=False,
         )
-        system.apply_forcefield(r_cut=2.5)
+        system.apply_forcefield(r_cut=2.5, auto_scale=False)
         with pytest.raises(ReferenceUnitError):
             system.reference_energy = "1.0 m"
 
@@ -565,9 +544,8 @@ class TestSystem(BaseTest):
             molecules=[polyethylene],
             force_field=[OPLS_AA()],
             density=1.0,
-            auto_scale=False,
         )
-        system.apply_forcefield(r_cut=2.5)
+        system.apply_forcefield(r_cut=2.5, auto_scale=False)
 
         system.reference_mass = 1.0 * u.amu
         assert system.reference_mass == 1.0 * u.amu
@@ -578,9 +556,8 @@ class TestSystem(BaseTest):
             molecules=[polyethylene],
             force_field=[OPLS_AA()],
             density=1.0,
-            auto_scale=False,
         )
-        system.apply_forcefield(r_cut=2.5)
+        system.apply_forcefield(r_cut=2.5, auto_scale=False)
         with pytest.raises(ReferenceUnitError):
             system.reference_mass = 1.0
 
@@ -590,9 +567,8 @@ class TestSystem(BaseTest):
             molecules=[polyethylene],
             force_field=[OPLS_AA()],
             density=1.0,
-            auto_scale=False,
         )
-        system.apply_forcefield(r_cut=2.5)
+        system.apply_forcefield(r_cut=2.5, auto_scale=False)
         system.reference_mass = "1 g"
         assert system.reference_mass == 1.0 * u.g
 
@@ -602,9 +578,8 @@ class TestSystem(BaseTest):
             molecules=[polyethylene],
             force_field=[OPLS_AA()],
             density=1.0,
-            auto_scale=False,
         )
-        system.apply_forcefield(r_cut=2.5)
+        system.apply_forcefield(r_cut=2.5, auto_scale=False)
         with pytest.raises(ReferenceUnitError):
             system.reference_mass = "1.0"
 
@@ -614,9 +589,8 @@ class TestSystem(BaseTest):
             molecules=[polyethylene],
             force_field=[OPLS_AA()],
             density=1.0,
-            auto_scale=False,
         )
-        system.apply_forcefield(r_cut=2.5)
+        system.apply_forcefield(r_cut=2.5, auto_scale=False)
         with pytest.raises(ReferenceUnitError):
             system.reference_mass = "1.0 invalid_unit"
 
@@ -626,9 +600,8 @@ class TestSystem(BaseTest):
             molecules=[polyethylene],
             force_field=[OPLS_AA()],
             density=1.0,
-            auto_scale=False,
         )
-        system.apply_forcefield(r_cut=2.5)
+        system.apply_forcefield(r_cut=2.5, auto_scale=False)
         with pytest.raises(ReferenceUnitError):
             system.reference_energy = 1.0 * u.m
 
@@ -638,9 +611,8 @@ class TestSystem(BaseTest):
             molecules=[polyethylene],
             force_field=[OPLS_AA()],
             density=1.0,
-            auto_scale=False,
         )
-        system.apply_forcefield(r_cut=2.5)
+        system.apply_forcefield(r_cut=2.5, auto_scale=False)
         with pytest.raises(ReferenceUnitError):
             system.reference_mass = "1.0 m"
 
@@ -650,10 +622,9 @@ class TestSystem(BaseTest):
             molecules=[polyethylene],
             force_field=None,
             density=1.0,
-            auto_scale=False,
         )
         with pytest.raises(ValueError):
-            system.apply_forcefield(r_cut=2.5)
+            system.apply_forcefield(r_cut=2.5, auto_scale=False)
 
     def test_forcefield_kwargs_attr(self, polyethylene):
         polyethylene = polyethylene(lengths=5, num_mols=1)
@@ -661,10 +632,13 @@ class TestSystem(BaseTest):
             molecules=[polyethylene],
             force_field=[OPLS_AA()],
             density=1.0,
-            auto_scale=False,
         )
         system.apply_forcefield(
-            r_cut=2.5, nlist_buffer=0.5, pppm_resolution=(4, 4, 4), pppm_order=3
+            r_cut=2.5,
+            auto_scale=False,
+            nlist_buffer=0.5,
+            pppm_resolution=(4, 4, 4),
+            pppm_order=3,
         )
         assert system._ff_kwargs["r_cut"] == 2.5
         assert system._ff_kwargs["nlist_buffer"] == 0.5
@@ -680,9 +654,8 @@ class TestSystem(BaseTest):
             x=1,
             y=1,
             n=4,
-            auto_scale=True,
         )
-        system.apply_forcefield(r_cut=2.5)
+        system.apply_forcefield(r_cut=2.5, auto_scale=True)
 
         assert system.n_mol_types == 1
         assert len(system.all_molecules) == len(polyethylene.molecules)
@@ -700,9 +673,8 @@ class TestSystem(BaseTest):
             x=1,
             y=1,
             n=4,
-            auto_scale=True,
         )
-        system.apply_forcefield(r_cut=2.5)
+        system.apply_forcefield(r_cut=2.5, auto_scale=True)
         assert system.n_mol_types == 1
         assert len(system.all_molecules) == len(benzene_mol.molecules)
         assert len(system.hoomd_forcefield) > 0
@@ -715,16 +687,18 @@ class TestSystem(BaseTest):
             molecules=pps_mol,
             density=0.5,
             force_field=OPLS_AA_PPS(),
-            auto_scale=True,
         )
-        no_scale.apply_forcefield(r_cut=2.5, scale_charges=False)
+        no_scale.apply_forcefield(
+            r_cut=2.5, scale_charges=False, auto_scale=True
+        )
 
         with_scale = Pack(
             molecules=pps_mol,
             density=0.5,
             force_field=OPLS_AA_PPS(),
-            auto_scale=True,
         )
-        with_scale.apply_forcefield(r_cut=2.5, scale_charges=True)
+        with_scale.apply_forcefield(
+            r_cut=2.5, scale_charges=True, auto_scale=True
+        )
         assert abs(no_scale.net_charge.value) > abs(with_scale.net_charge.value)
         assert np.allclose(0, with_scale.net_charge.value, atol=1e-30)

--- a/hoomd_organics/tests/base/test_system.py
+++ b/hoomd_organics/tests/base/test_system.py
@@ -14,12 +14,10 @@ from hoomd_organics.utils.exceptions import ForceFieldError, ReferenceUnitError
 class TestSystem(BaseTest):
     def test_single_mol_type(self, benzene_molecule):
         benzene_mols = benzene_molecule(n_mols=3)
-        system = Pack(
-            molecules=[benzene_mols],
-            density=0.8,
-            force_field=OPLS_AA(),
+        system = Pack(molecules=[benzene_mols], density=0.8)
+        system.apply_forcefield(
+            r_cut=2.5, force_field=OPLS_AA(), auto_scale=True
         )
-        system.apply_forcefield(r_cut=2.5, auto_scale=True)
         assert system.n_mol_types == 1
         assert len(system.all_molecules) == len(benzene_mols.molecules)
         assert system.gmso_system.is_typed()
@@ -31,12 +29,10 @@ class TestSystem(BaseTest):
     def test_multiple_mol_types(self, benzene_molecule, ethane_molecule):
         benzene_mol = benzene_molecule(n_mols=3)
         ethane_mol = ethane_molecule(n_mols=2)
-        system = Pack(
-            molecules=[benzene_mol, ethane_mol],
-            density=0.8,
-            force_field=OPLS_AA(),
+        system = Pack(molecules=[benzene_mol, ethane_mol], density=0.8)
+        system.apply_forcefield(
+            r_cut=2.5, force_field=OPLS_AA(), auto_scale=True
         )
-        system.apply_forcefield(r_cut=2.5, auto_scale=True)
         assert system.n_mol_types == 2
         assert len(system.all_molecules) == len(benzene_mol.molecules) + len(
             ethane_mol.molecules
@@ -58,12 +54,12 @@ class TestSystem(BaseTest):
     ):
         dimethylether_mol = dimethylether_molecule(n_mols=3)
         pps_mol = pps_molecule(n_mols=2)
-        system = Pack(
-            molecules=[dimethylether_mol, pps_mol],
-            density=0.8,
+        system = Pack(molecules=[dimethylether_mol, pps_mol], density=0.8)
+        system.apply_forcefield(
+            r_cut=2.5,
             force_field=[OPLS_AA_DIMETHYLETHER(), OPLS_AA_PPS()],
+            auto_scale=True,
         )
-        system.apply_forcefield(r_cut=2.5, auto_scale=True)
         assert system.n_mol_types == 2
         assert len(system.all_molecules) == len(
             dimethylether_mol.molecules
@@ -89,25 +85,20 @@ class TestSystem(BaseTest):
 
     def test_system_from_mol2_mol_parameterization(self, benzene_molecule_mol2):
         benzene_mol = benzene_molecule_mol2(n_mols=3)
-        system = Pack(
-            molecules=[benzene_mol],
-            density=0.8,
-            force_field=OPLS_AA(),
+        system = Pack(molecules=[benzene_mol], density=0.8)
+        system.apply_forcefield(
+            r_cut=2.5, force_field=OPLS_AA(), auto_scale=True
         )
-        system.apply_forcefield(r_cut=2.5, auto_scale=True)
         assert system.gmso_system.is_typed()
         assert len(system.hoomd_forcefield) > 0
         assert system.n_particles == system.hoomd_snapshot.particles.N
 
     def test_remove_hydrogen(self, benzene_molecule):
         benzene_mol = benzene_molecule(n_mols=3)
-        system = Pack(
-            molecules=[benzene_mol],
-            density=0.8,
-            force_field=OPLS_AA(),
-        )
+        system = Pack(molecules=[benzene_mol], density=0.8)
         system.apply_forcefield(
             r_cut=2.5,
+            force_field=OPLS_AA(),
             remove_hydrogens=True,
             auto_scale=True,
         )
@@ -130,10 +121,12 @@ class TestSystem(BaseTest):
         system = Pack(
             molecules=[benzene_mol],
             density=0.8,
-            force_field=OPLS_AA(),
         )
         system.apply_forcefield(
-            r_cut=2.5, remove_hydrogens=False, auto_scale=True
+            r_cut=2.5,
+            force_field=OPLS_AA(),
+            remove_hydrogens=False,
+            auto_scale=True,
         )
         for site in system.gmso_system.sites:
             if site.name == "H":
@@ -152,10 +145,12 @@ class TestSystem(BaseTest):
         system = Pack(
             molecules=[benzene_mol],
             density=0.8,
-            force_field=OPLS_AA(),
         )
         system.apply_forcefield(
-            r_cut=2.5, remove_hydrogens=False, auto_scale=True
+            r_cut=2.5,
+            force_field=OPLS_AA(),
+            remove_hydrogens=False,
+            auto_scale=True,
         )
         hydrogens = [
             site
@@ -173,10 +168,10 @@ class TestSystem(BaseTest):
         system = Pack(
             molecules=[benzene_mols],
             density=0.8,
-            force_field=OPLS_AA(),
         )
         system.apply_forcefield(
             r_cut=2.5,
+            force_field=OPLS_AA(),
             remove_hydrogens=True,
             scale_charges=False,
             auto_scale=False,
@@ -196,16 +191,15 @@ class TestSystem(BaseTest):
         low_density_system = Pack(
             molecules=[benzene_mol],
             density=0.1,
-            force_field=OPLS_AA(),
         )
-        low_density_system.apply_forcefield(r_cut=2.5, auto_scale=True)
+        low_density_system.apply_forcefield(
+            r_cut=2.5, force_field=OPLS_AA(), auto_scale=True
+        )
 
-        high_density_system = Pack(
-            molecules=[benzene_mol],
-            density=0.9,
-            force_field=OPLS_AA(),
+        high_density_system = Pack(molecules=[benzene_mol], density=0.9)
+        high_density_system.apply_forcefield(
+            r_cut=2.5, force_field=OPLS_AA(), auto_scale=True
         )
-        high_density_system.apply_forcefield(r_cut=2.5, auto_scale=True)
         assert all(
             low_density_system.target_box > high_density_system.target_box
         )
@@ -221,10 +215,11 @@ class TestSystem(BaseTest):
         polyethylene = polyethylene(lengths=5, num_mols=5)
         system = Pack(
             molecules=[polyethylene],
-            force_field=[OPLS_AA()],
             density=1.0,
         )
-        system.apply_forcefield(r_cut=2.5, auto_scale=True)
+        system.apply_forcefield(
+            r_cut=2.5, force_field=[OPLS_AA()], auto_scale=True
+        )
 
         assert np.allclose(
             system.reference_length.to("angstrom").value, 3.5, atol=1e-3
@@ -239,10 +234,11 @@ class TestSystem(BaseTest):
         polyethylene = polyethylene(lengths=5, num_mols=5)
         system = Pack(
             molecules=[polyethylene],
-            force_field=[OPLS_AA()],
             density=1.0,
         )
-        system.apply_forcefield(r_cut=2.5, auto_scale=True)
+        system.apply_forcefield(
+            r_cut=2.5, force_field=[OPLS_AA()], auto_scale=True
+        )
         total_red_mass = sum(system.hoomd_snapshot.particles.mass)
         assert np.allclose(
             system.mass,
@@ -254,10 +250,11 @@ class TestSystem(BaseTest):
         polyethylene = polyethylene(lengths=5, num_mols=5)
         system = Pack(
             molecules=[polyethylene],
-            force_field=[OPLS_AA()],
             density=1.0,
         )
-        system.apply_forcefield(r_cut=2.5, auto_scale=True)
+        system.apply_forcefield(
+            r_cut=2.5, force_field=[OPLS_AA()], auto_scale=True
+        )
         assert np.allclose(
             system.reference_energy.to("kcal/mol").value, 0.066, atol=1e-3
         )
@@ -266,10 +263,11 @@ class TestSystem(BaseTest):
         polyethylene = polyethylene(lengths=5, num_mols=1)
         system = Pack(
             molecules=[polyethylene],
-            force_field=[OPLS_AA()],
             density=1.0,
         )
-        system.apply_forcefield(r_cut=2.5, auto_scale=False)
+        system.apply_forcefield(
+            r_cut=2.5, force_field=[OPLS_AA()], auto_scale=False
+        )
         assert system._snap_refs == system.reference_values
         assert system._ff_refs == system.reference_values
         init_snap = system.hoomd_snapshot
@@ -287,10 +285,11 @@ class TestSystem(BaseTest):
         polyethylene = polyethylene(lengths=5, num_mols=1)
         system = Pack(
             molecules=[polyethylene],
-            force_field=[OPLS_AA()],
             density=1.0,
         )
-        system.apply_forcefield(r_cut=2.5, auto_scale=False)
+        system.apply_forcefield(
+            r_cut=2.5, force_field=[OPLS_AA()], auto_scale=False
+        )
         system.reference_length = 1 * u.angstrom
         system.reference_energy = 1 * u.kcal / u.mol
         system.reference_mass = 1 * u.amu
@@ -306,10 +305,10 @@ class TestSystem(BaseTest):
 
     def test_set_ref_values(self, polyethylene):
         polyethylene = polyethylene(lengths=5, num_mols=1)
-        system = Pack(
-            molecules=[polyethylene], force_field=[OPLS_AA()], density=1.0
+        system = Pack(molecules=[polyethylene], density=1.0)
+        system.apply_forcefield(
+            r_cut=2.5, force_field=[OPLS_AA()], auto_scale=False
         )
-        system.apply_forcefield(r_cut=2.5, auto_scale=False)
         ref_value_dict = {
             "length": 1 * u.angstrom,
             "energy": 3.0 * u.kcal / u.mol,
@@ -324,10 +323,11 @@ class TestSystem(BaseTest):
         polyethylene = polyethylene(lengths=5, num_mols=1)
         system = Pack(
             molecules=[polyethylene],
-            force_field=[OPLS_AA()],
             density=1.0,
         )
-        system.apply_forcefield(r_cut=2.5, auto_scale=False)
+        system.apply_forcefield(
+            r_cut=2.5, force_field=[OPLS_AA()], auto_scale=False
+        )
         ref_value_dict = {
             "length": "1 angstrom",
             "energy": "3 kcal/mol",
@@ -342,10 +342,11 @@ class TestSystem(BaseTest):
         polyethylene = polyethylene(lengths=5, num_mols=1)
         system = Pack(
             molecules=[polyethylene],
-            force_field=[OPLS_AA()],
             density=1.0,
         )
-        system.apply_forcefield(r_cut=2.5, auto_scale=False)
+        system.apply_forcefield(
+            r_cut=2.5, force_field=[OPLS_AA()], auto_scale=False
+        )
         ref_value_dict = {
             "length": 1 * u.angstrom,
             "energy": 3.0 * u.kcal / u.mol,
@@ -357,10 +358,11 @@ class TestSystem(BaseTest):
         polyethylene = polyethylene(lengths=5, num_mols=5)
         system = Pack(
             molecules=[polyethylene],
-            force_field=[OPLS_AA()],
             density=1.0,
         )
-        system.apply_forcefield(r_cut=2.5, auto_scale=False)
+        system.apply_forcefield(
+            r_cut=2.5, force_field=[OPLS_AA()], auto_scale=False
+        )
         ref_value_dict = {
             "length": 1 * u.angstrom,
             "energy": 3.0 * u.kcal / u.mol,
@@ -373,10 +375,11 @@ class TestSystem(BaseTest):
         polyethylene = polyethylene(lengths=5, num_mols=5)
         system = Pack(
             molecules=[polyethylene],
-            force_field=[OPLS_AA()],
             density=1.0,
         )
-        system.apply_forcefield(r_cut=2.5, auto_scale=True)
+        system.apply_forcefield(
+            r_cut=2.5, force_field=[OPLS_AA()], auto_scale=True
+        )
         ref_value_dict = {
             "length": 1 * u.angstrom,
             "energy": 3.0 * u.kcal / u.mol,
@@ -389,10 +392,11 @@ class TestSystem(BaseTest):
         polyethylene = polyethylene(lengths=5, num_mols=1)
         system = Pack(
             molecules=[polyethylene],
-            force_field=[OPLS_AA()],
             density=1.0,
         )
-        system.apply_forcefield(r_cut=2.5, auto_scale=False)
+        system.apply_forcefield(
+            r_cut=2.5, force_field=[OPLS_AA()], auto_scale=False
+        )
         system.reference_length = 1 * u.angstrom
         assert system.reference_length == 1 * u.angstrom
 
@@ -400,10 +404,11 @@ class TestSystem(BaseTest):
         polyethylene = polyethylene(lengths=5, num_mols=5)
         system = Pack(
             molecules=[polyethylene],
-            force_field=[OPLS_AA()],
             density=1.0,
         )
-        system.apply_forcefield(r_cut=2.5, auto_scale=False)
+        system.apply_forcefield(
+            r_cut=2.5, force_field=[OPLS_AA()], auto_scale=False
+        )
         with pytest.raises(ReferenceUnitError):
             system.reference_length = 1.0
 
@@ -411,10 +416,11 @@ class TestSystem(BaseTest):
         polyethylene = polyethylene(lengths=5, num_mols=1)
         system = Pack(
             molecules=[polyethylene],
-            force_field=[OPLS_AA()],
             density=1.0,
         )
-        system.apply_forcefield(r_cut=2.5, auto_scale=False)
+        system.apply_forcefield(
+            r_cut=2.5, force_field=[OPLS_AA()], auto_scale=False
+        )
         system.reference_length = "1 angstrom"
         assert system.reference_length == 1 * u.angstrom
 
@@ -422,10 +428,11 @@ class TestSystem(BaseTest):
         polyethylene = polyethylene(lengths=5, num_mols=1)
         system = Pack(
             molecules=[polyethylene],
-            force_field=[OPLS_AA()],
             density=1.0,
         )
-        system.apply_forcefield(r_cut=2.5, auto_scale=False)
+        system.apply_forcefield(
+            r_cut=2.5, force_field=[OPLS_AA()], auto_scale=False
+        )
         with pytest.raises(ReferenceUnitError):
             system.reference_length = "1.0"
 
@@ -433,10 +440,11 @@ class TestSystem(BaseTest):
         polyethylene = polyethylene(lengths=5, num_mols=1)
         system = Pack(
             molecules=[polyethylene],
-            force_field=[OPLS_AA()],
             density=1.0,
         )
-        system.apply_forcefield(r_cut=2.5, auto_scale=False)
+        system.apply_forcefield(
+            r_cut=2.5, force_field=[OPLS_AA()], auto_scale=False
+        )
         with pytest.raises(ReferenceUnitError):
             system.reference_length = "1.0 invalid_unit"
 
@@ -444,10 +452,11 @@ class TestSystem(BaseTest):
         polyethylene = polyethylene(lengths=5, num_mols=1)
         system = Pack(
             molecules=[polyethylene],
-            force_field=[OPLS_AA()],
             density=1.0,
         )
-        system.apply_forcefield(r_cut=2.5, auto_scale=False)
+        system.apply_forcefield(
+            r_cut=2.5, force_field=[OPLS_AA()], auto_scale=False
+        )
         with pytest.raises(ReferenceUnitError):
             system.reference_length = 1.0 * u.g
 
@@ -455,10 +464,11 @@ class TestSystem(BaseTest):
         polyethylene = polyethylene(lengths=5, num_mols=1)
         system = Pack(
             molecules=[polyethylene],
-            force_field=[OPLS_AA()],
             density=1.0,
         )
-        system.apply_forcefield(r_cut=2.5, auto_scale=False)
+        system.apply_forcefield(
+            r_cut=2.5, force_field=[OPLS_AA()], auto_scale=False
+        )
         with pytest.raises(ReferenceUnitError):
             system.reference_length = "1.0 g"
 
@@ -466,10 +476,11 @@ class TestSystem(BaseTest):
         polyethylene = polyethylene(lengths=5, num_mols=1)
         system = Pack(
             molecules=[polyethylene],
-            force_field=[OPLS_AA()],
             density=1.0,
         )
-        system.apply_forcefield(r_cut=2.5, auto_scale=True)
+        system.apply_forcefield(
+            r_cut=2.5, force_field=[OPLS_AA()], auto_scale=True
+        )
         system.reference_length = 1 * u.angstrom
         assert system.reference_length == 1 * u.angstrom
 
@@ -477,10 +488,11 @@ class TestSystem(BaseTest):
         polyethylene = polyethylene(lengths=5, num_mols=1)
         system = Pack(
             molecules=[polyethylene],
-            force_field=[OPLS_AA()],
             density=1.0,
         )
-        system.apply_forcefield(r_cut=2.5, auto_scale=False)
+        system.apply_forcefield(
+            r_cut=2.5, force_field=[OPLS_AA()], auto_scale=False
+        )
         system.reference_energy = 1 * u.kcal / u.mol
         assert system.reference_energy == 1 * u.kcal / u.mol
 
@@ -488,10 +500,11 @@ class TestSystem(BaseTest):
         polyethylene = polyethylene(lengths=5, num_mols=1)
         system = Pack(
             molecules=[polyethylene],
-            force_field=[OPLS_AA()],
             density=1.0,
         )
-        system.apply_forcefield(r_cut=2.5, auto_scale=False)
+        system.apply_forcefield(
+            r_cut=2.5, force_field=[OPLS_AA()], auto_scale=False
+        )
         with pytest.raises(ReferenceUnitError):
             system.reference_energy = 1.0
 
@@ -499,10 +512,11 @@ class TestSystem(BaseTest):
         polyethylene = polyethylene(lengths=5, num_mols=1)
         system = Pack(
             molecules=[polyethylene],
-            force_field=[OPLS_AA()],
             density=1.0,
         )
-        system.apply_forcefield(r_cut=2.5, auto_scale=False)
+        system.apply_forcefield(
+            r_cut=2.5, force_field=[OPLS_AA()], auto_scale=False
+        )
         system.reference_energy = "1 kJ"
         assert system.reference_energy == 1 * u.kJ
 
@@ -510,10 +524,11 @@ class TestSystem(BaseTest):
         polyethylene = polyethylene(lengths=5, num_mols=1)
         system = Pack(
             molecules=[polyethylene],
-            force_field=[OPLS_AA()],
             density=1.0,
         )
-        system.apply_forcefield(r_cut=2.5, auto_scale=False)
+        system.apply_forcefield(
+            r_cut=2.5, force_field=[OPLS_AA()], auto_scale=False
+        )
         system.reference_energy = "1 kcal/mol"
         assert system.reference_energy == 1 * u.kcal / u.mol
 
@@ -521,10 +536,11 @@ class TestSystem(BaseTest):
         polyethylene = polyethylene(lengths=5, num_mols=1)
         system = Pack(
             molecules=[polyethylene],
-            force_field=[OPLS_AA()],
             density=1.0,
         )
-        system.apply_forcefield(r_cut=2.5, auto_scale=False)
+        system.apply_forcefield(
+            r_cut=2.5, force_field=[OPLS_AA()], auto_scale=False
+        )
         with pytest.raises(ReferenceUnitError):
             system.reference_energy = "1.0"
 
@@ -532,10 +548,11 @@ class TestSystem(BaseTest):
         polyethylene = polyethylene(lengths=5, num_mols=1)
         system = Pack(
             molecules=[polyethylene],
-            force_field=[OPLS_AA()],
             density=1.0,
         )
-        system.apply_forcefield(r_cut=2.5, auto_scale=False)
+        system.apply_forcefield(
+            r_cut=2.5, force_field=[OPLS_AA()], auto_scale=False
+        )
         with pytest.raises(ReferenceUnitError):
             system.reference_energy = "1.0 invalid_unit"
 
@@ -543,10 +560,11 @@ class TestSystem(BaseTest):
         polyethylene = polyethylene(lengths=5, num_mols=1)
         system = Pack(
             molecules=[polyethylene],
-            force_field=[OPLS_AA()],
             density=1.0,
         )
-        system.apply_forcefield(r_cut=2.5, auto_scale=False)
+        system.apply_forcefield(
+            r_cut=2.5, force_field=[OPLS_AA()], auto_scale=False
+        )
         with pytest.raises(ReferenceUnitError):
             system.reference_energy = 1.0 * u.g
 
@@ -554,10 +572,11 @@ class TestSystem(BaseTest):
         polyethylene = polyethylene(lengths=5, num_mols=1)
         system = Pack(
             molecules=[polyethylene],
-            force_field=[OPLS_AA()],
             density=1.0,
         )
-        system.apply_forcefield(r_cut=2.5, auto_scale=False)
+        system.apply_forcefield(
+            r_cut=2.5, force_field=[OPLS_AA()], auto_scale=False
+        )
         with pytest.raises(ReferenceUnitError):
             system.reference_energy = "1.0 m"
 
@@ -565,10 +584,11 @@ class TestSystem(BaseTest):
         polyethylene = polyethylene(lengths=5, num_mols=1)
         system = Pack(
             molecules=[polyethylene],
-            force_field=[OPLS_AA()],
             density=1.0,
         )
-        system.apply_forcefield(r_cut=2.5, auto_scale=True)
+        system.apply_forcefield(
+            r_cut=2.5, force_field=[OPLS_AA()], auto_scale=True
+        )
         system.reference_energy = 1 * u.kcal / u.mol
         assert system.reference_energy == 1 * u.kcal / u.mol
 
@@ -576,10 +596,11 @@ class TestSystem(BaseTest):
         polyethylene = polyethylene(lengths=5, num_mols=1)
         system = Pack(
             molecules=[polyethylene],
-            force_field=[OPLS_AA()],
             density=1.0,
         )
-        system.apply_forcefield(r_cut=2.5, auto_scale=False)
+        system.apply_forcefield(
+            r_cut=2.5, force_field=[OPLS_AA()], auto_scale=False
+        )
 
         system.reference_mass = 1.0 * u.amu
         assert system.reference_mass == 1.0 * u.amu
@@ -588,10 +609,11 @@ class TestSystem(BaseTest):
         polyethylene = polyethylene(lengths=5, num_mols=1)
         system = Pack(
             molecules=[polyethylene],
-            force_field=[OPLS_AA()],
             density=1.0,
         )
-        system.apply_forcefield(r_cut=2.5, auto_scale=False)
+        system.apply_forcefield(
+            r_cut=2.5, force_field=[OPLS_AA()], auto_scale=False
+        )
         with pytest.raises(ReferenceUnitError):
             system.reference_mass = 1.0
 
@@ -599,10 +621,11 @@ class TestSystem(BaseTest):
         polyethylene = polyethylene(lengths=5, num_mols=1)
         system = Pack(
             molecules=[polyethylene],
-            force_field=[OPLS_AA()],
             density=1.0,
         )
-        system.apply_forcefield(r_cut=2.5, auto_scale=False)
+        system.apply_forcefield(
+            r_cut=2.5, force_field=[OPLS_AA()], auto_scale=False
+        )
         system.reference_mass = "1 g"
         assert system.reference_mass == 1.0 * u.g
 
@@ -610,10 +633,11 @@ class TestSystem(BaseTest):
         polyethylene = polyethylene(lengths=5, num_mols=1)
         system = Pack(
             molecules=[polyethylene],
-            force_field=[OPLS_AA()],
             density=1.0,
         )
-        system.apply_forcefield(r_cut=2.5, auto_scale=False)
+        system.apply_forcefield(
+            r_cut=2.5, force_field=[OPLS_AA()], auto_scale=False
+        )
         with pytest.raises(ReferenceUnitError):
             system.reference_mass = "1.0"
 
@@ -621,10 +645,11 @@ class TestSystem(BaseTest):
         polyethylene = polyethylene(lengths=5, num_mols=1)
         system = Pack(
             molecules=[polyethylene],
-            force_field=[OPLS_AA()],
             density=1.0,
         )
-        system.apply_forcefield(r_cut=2.5, auto_scale=False)
+        system.apply_forcefield(
+            r_cut=2.5, force_field=[OPLS_AA()], auto_scale=False
+        )
         with pytest.raises(ReferenceUnitError):
             system.reference_mass = "1.0 invalid_unit"
 
@@ -632,10 +657,11 @@ class TestSystem(BaseTest):
         polyethylene = polyethylene(lengths=5, num_mols=1)
         system = Pack(
             molecules=[polyethylene],
-            force_field=[OPLS_AA()],
             density=1.0,
         )
-        system.apply_forcefield(r_cut=2.5, auto_scale=False)
+        system.apply_forcefield(
+            r_cut=2.5, force_field=[OPLS_AA()], auto_scale=False
+        )
         with pytest.raises(ReferenceUnitError):
             system.reference_energy = 1.0 * u.m
 
@@ -643,10 +669,11 @@ class TestSystem(BaseTest):
         polyethylene = polyethylene(lengths=5, num_mols=1)
         system = Pack(
             molecules=[polyethylene],
-            force_field=[OPLS_AA()],
             density=1.0,
         )
-        system.apply_forcefield(r_cut=2.5, auto_scale=False)
+        system.apply_forcefield(
+            r_cut=2.5, force_field=[OPLS_AA()], auto_scale=False
+        )
         with pytest.raises(ReferenceUnitError):
             system.reference_mass = "1.0 m"
 
@@ -654,10 +681,11 @@ class TestSystem(BaseTest):
         polyethylene = polyethylene(lengths=5, num_mols=1)
         system = Pack(
             molecules=[polyethylene],
-            force_field=[OPLS_AA()],
             density=1.0,
         )
-        system.apply_forcefield(r_cut=2.5, auto_scale=True)
+        system.apply_forcefield(
+            r_cut=2.5, force_field=[OPLS_AA()], auto_scale=True
+        )
 
         system.reference_mass = 1.0 * u.amu
         assert system.reference_mass == 1.0 * u.amu
@@ -666,21 +694,22 @@ class TestSystem(BaseTest):
         polyethylene = polyethylene(lengths=5, num_mols=1)
         system = Pack(
             molecules=[polyethylene],
-            force_field=None,
             density=1.0,
         )
         with pytest.raises(ValueError):
-            system.apply_forcefield(r_cut=2.5, auto_scale=False)
+            system.apply_forcefield(
+                r_cut=2.5, force_field=None, auto_scale=False
+            )
 
     def test_forcefield_kwargs_attr(self, polyethylene):
         polyethylene = polyethylene(lengths=5, num_mols=1)
         system = Pack(
             molecules=[polyethylene],
-            force_field=[OPLS_AA()],
             density=1.0,
         )
         system.apply_forcefield(
             r_cut=2.5,
+            force_field=[OPLS_AA()],
             auto_scale=False,
             nlist_buffer=0.5,
             pppm_resolution=(4, 4, 4),
@@ -695,31 +724,33 @@ class TestSystem(BaseTest):
         polyethylene = polyethylene(lengths=5, num_mols=1)
         system = Pack(
             molecules=[polyethylene],
-            force_field=[OPLS_AA()],
             density=1.0,
         )
-        system.apply_forcefield(r_cut=2.5, auto_scale=True)
+        system.apply_forcefield(
+            r_cut=2.5, force_field=[OPLS_AA()], auto_scale=True
+        )
 
         hoomd_ff = system.hoomd_forcefield
 
         with pytest.raises(ForceFieldError):
-            Pack(
+            system = Pack(
                 molecules=[polyethylene],
-                force_field=hoomd_ff,
                 density=1.0,
             )
+            system.apply_forcefield(r_cut=2.5, force_field=hoomd_ff)
 
     def test_lattice_polymer(self, polyethylene):
         polyethylene = polyethylene(lengths=2, num_mols=32)
         system = Lattice(
             molecules=[polyethylene],
-            force_field=[OPLS_AA()],
             density=1.0,
             x=1,
             y=1,
             n=4,
         )
-        system.apply_forcefield(r_cut=2.5, auto_scale=True)
+        system.apply_forcefield(
+            r_cut=2.5, force_field=[OPLS_AA()], auto_scale=True
+        )
 
         assert system.n_mol_types == 1
         assert len(system.all_molecules) == len(polyethylene.molecules)
@@ -732,13 +763,14 @@ class TestSystem(BaseTest):
         benzene_mol = benzene_molecule(n_mols=32)
         system = Lattice(
             molecules=[benzene_mol],
-            force_field=OPLS_AA(),
             density=1.0,
             x=1,
             y=1,
             n=4,
         )
-        system.apply_forcefield(r_cut=2.5, auto_scale=True)
+        system.apply_forcefield(
+            r_cut=2.5, force_field=OPLS_AA(), auto_scale=True
+        )
         assert system.n_mol_types == 1
         assert len(system.all_molecules) == len(benzene_mol.molecules)
         assert len(system.hoomd_forcefield) > 0
@@ -750,19 +782,23 @@ class TestSystem(BaseTest):
         no_scale = Pack(
             molecules=pps_mol,
             density=0.5,
-            force_field=OPLS_AA_PPS(),
         )
         no_scale.apply_forcefield(
-            r_cut=2.5, scale_charges=False, auto_scale=True
+            r_cut=2.5,
+            force_field=OPLS_AA_PPS(),
+            scale_charges=False,
+            auto_scale=True,
         )
 
         with_scale = Pack(
             molecules=pps_mol,
             density=0.5,
-            force_field=OPLS_AA_PPS(),
         )
         with_scale.apply_forcefield(
-            r_cut=2.5, scale_charges=True, auto_scale=True
+            r_cut=2.5,
+            force_field=OPLS_AA_PPS(),
+            scale_charges=True,
+            auto_scale=True,
         )
         assert abs(no_scale.net_charge.value) > abs(with_scale.net_charge.value)
         assert np.allclose(0, with_scale.net_charge.value, atol=1e-30)

--- a/hoomd_organics/tests/base_test.py
+++ b/hoomd_organics/tests/base_test.py
@@ -111,8 +111,10 @@ class BaseTest:
 
     @pytest.fixture()
     def benzene_molecule(self, benzene_smiles):
-        def _benzene_molecule(n_mols):
-            benzene = Molecule(num_mols=n_mols, smiles=benzene_smiles)
+        def _benzene_molecule(n_mols, force_field=None):
+            benzene = Molecule(
+                num_mols=n_mols, smiles=benzene_smiles, force_field=force_field
+            )
             return benzene
 
         return _benzene_molecule

--- a/hoomd_organics/tests/base_test.py
+++ b/hoomd_organics/tests/base_test.py
@@ -264,4 +264,4 @@ class BaseTest:
                 "A": dict(epsilon=1.0, sigma=1.0),
             },
         )
-        return ff.hoomd_forcefield
+        return ff.hoomd_forces

--- a/hoomd_organics/tests/base_test.py
+++ b/hoomd_organics/tests/base_test.py
@@ -218,7 +218,6 @@ class BaseTest:
             molecules=[benzene],
             density=0.2,
             force_field=OPLS_AA(),
-            auto_scale=True,
         )
         system.apply_forcefield(r_cut=2.5, auto_scale=True)
         return system
@@ -230,7 +229,6 @@ class BaseTest:
         system = Pack(
             molecules=[benzene_mols],
             density=0.5,
-            auto_scale=False,
         )
         return system
 
@@ -241,9 +239,10 @@ class BaseTest:
             molecules=polyethylene_mol,
             density=0.5,
             force_field=OPLS_AA(),
-            auto_scale=True,
         )
-        system.apply_forcefield(r_cut=2.5, remove_hydrogens=True)
+        system.apply_forcefield(
+            r_cut=2.5, remove_hydrogens=True, auto_scale=True
+        )
         return system
 
     @pytest.fixture()

--- a/hoomd_organics/tests/base_test.py
+++ b/hoomd_organics/tests/base_test.py
@@ -217,9 +217,10 @@ class BaseTest:
         system = Pack(
             molecules=[benzene],
             density=0.2,
-            force_field=OPLS_AA(),
         )
-        system.apply_forcefield(r_cut=2.5, auto_scale=True)
+        system.apply_forcefield(
+            r_cut=2.5, force_field=OPLS_AA(), auto_scale=True
+        )
         return system
 
     @pytest.fixture()
@@ -238,10 +239,12 @@ class BaseTest:
         system = Pack(
             molecules=polyethylene_mol,
             density=0.5,
-            force_field=OPLS_AA(),
         )
         system.apply_forcefield(
-            r_cut=2.5, remove_hydrogens=True, auto_scale=True
+            r_cut=2.5,
+            remove_hydrogens=True,
+            force_field=OPLS_AA(),
+            auto_scale=True,
         )
         return system
 

--- a/hoomd_organics/tests/library/test_forcefields.py
+++ b/hoomd_organics/tests/library/test_forcefields.py
@@ -55,37 +55,37 @@ class TestForceFields:
             dihedrals={"A-A-A-A": dict(phi0=0.0, k=100, d=-1, n=1)},
         )
 
-        assert isinstance(ff.hoomd_forcefield[0], hoomd.md.pair.pair.LJ)
-        assert isinstance(ff.hoomd_forcefield[1], hoomd.md.bond.Harmonic)
-        assert isinstance(ff.hoomd_forcefield[2], hoomd.md.angle.Harmonic)
-        assert isinstance(ff.hoomd_forcefield[3], hoomd.md.dihedral.Periodic)
+        assert isinstance(ff.hoomd_forces[0], hoomd.md.pair.pair.LJ)
+        assert isinstance(ff.hoomd_forces[1], hoomd.md.bond.Harmonic)
+        assert isinstance(ff.hoomd_forces[2], hoomd.md.angle.Harmonic)
+        assert isinstance(ff.hoomd_forces[3], hoomd.md.dihedral.Periodic)
 
         pair_types = [("A", "A"), ("A", "B"), ("B", "B")]
-        for param in ff.hoomd_forcefield[0].params:
+        for param in ff.hoomd_forces[0].params:
             assert param in pair_types
             if param == ("A", "A"):
-                assert ff.hoomd_forcefield[0].params[param]["sigma"] == 1.0
+                assert ff.hoomd_forces[0].params[param]["sigma"] == 1.0
             if param == ("B", "B"):
-                assert ff.hoomd_forcefield[0].params[param]["epsilon"] == 2.0
+                assert ff.hoomd_forces[0].params[param]["epsilon"] == 2.0
             if param == ("A", "B"):
-                assert ff.hoomd_forcefield[0].params[param]["epsilon"] == 1.5
+                assert ff.hoomd_forces[0].params[param]["epsilon"] == 1.5
 
         bond_types = [("A-A"), ("A-B")]
-        for param in ff.hoomd_forcefield[1].params:
+        for param in ff.hoomd_forces[1].params:
             assert param in bond_types
-            assert ff.hoomd_forcefield[1].params[param]["r0"] == 1.1
-            assert ff.hoomd_forcefield[1].params[param]["k"] == 300
+            assert ff.hoomd_forces[1].params[param]["r0"] == 1.1
+            assert ff.hoomd_forces[1].params[param]["k"] == 300
 
         angle_types = [("A-A-A"), ("A-B-A")]
-        for param in ff.hoomd_forcefield[2].params:
+        for param in ff.hoomd_forces[2].params:
             assert param in angle_types
-            assert ff.hoomd_forcefield[2].params[param]["t0"] == 2.0
-            assert ff.hoomd_forcefield[2].params[param]["k"] == 200
+            assert ff.hoomd_forces[2].params[param]["t0"] == 2.0
+            assert ff.hoomd_forces[2].params[param]["k"] == 200
 
         dihedral_types = [("A-A-A-A")]
-        for param in ff.hoomd_forcefield[3].params:
+        for param in ff.hoomd_forces[3].params:
             assert param in dihedral_types
-            assert ff.hoomd_forcefield[3].params[param]["phi0"] == 0.0
-            assert ff.hoomd_forcefield[3].params[param]["k"] == 100
-            assert ff.hoomd_forcefield[3].params[param]["d"] == -1
-            assert ff.hoomd_forcefield[3].params[param]["n"] == 1
+            assert ff.hoomd_forces[3].params[param]["phi0"] == 0.0
+            assert ff.hoomd_forces[3].params[param]["k"] == 100
+            assert ff.hoomd_forces[3].params[param]["d"] == -1
+            assert ff.hoomd_forces[3].params[param]["n"] == 1

--- a/hoomd_organics/tests/library/test_tensile.py
+++ b/hoomd_organics/tests/library/test_tensile.py
@@ -15,9 +15,8 @@ class TestTensileSimulation(BaseTest):
             x=1.2,
             y=1.2,
             n=4,
-            auto_scale=True,
         )
-        system.apply_forcefield(r_cut=2.5)
+        system.apply_forcefield(r_cut=2.5, auto_scale=True)
 
         tensile_sim = Tensile(
             initial_state=system.hoomd_snapshot,

--- a/hoomd_organics/tests/library/test_tensile.py
+++ b/hoomd_organics/tests/library/test_tensile.py
@@ -10,13 +10,14 @@ class TestTensileSimulation(BaseTest):
         pps = PPS(lengths=6, num_mols=32)
         system = Lattice(
             molecules=[pps],
-            force_field=[OPLS_AA_PPS()],
             density=1.0,
             x=1.2,
             y=1.2,
             n=4,
         )
-        system.apply_forcefield(r_cut=2.5, auto_scale=True)
+        system.apply_forcefield(
+            r_cut=2.5, force_field=[OPLS_AA_PPS()], auto_scale=True
+        )
 
         tensile_sim = Tensile(
             initial_state=system.hoomd_snapshot,

--- a/hoomd_organics/tests/utils/test_ff_utils.py
+++ b/hoomd_organics/tests/utils/test_ff_utils.py
@@ -4,24 +4,20 @@ import pytest
 from gmso.core.forcefield import ForceField
 
 from hoomd_organics.tests import BaseTest
-from hoomd_organics.utils.base_types import FF_Types
 from hoomd_organics.utils.ff_utils import find_xml_ff, xml_to_gmso_ff
 
 
 class TestFFUtils(BaseTest):
     def test_find_xml_ff(self):
-        ff_xml_path, ff_type = find_xml_ff("oplsaa.xml")
-        assert ff_type == FF_Types.XML
+        ff_xml_path = find_xml_ff("oplsaa.xml")
         assert os.path.exists(ff_xml_path)
 
     def test_find_xml_only_file_name(self):
-        ff_xml_path, ff_type = find_xml_ff("oplsaa")
-        assert ff_type == FF_Types.XML
+        ff_xml_path = find_xml_ff("oplsaa")
         assert os.path.exists(ff_xml_path)
 
     def test_find_xml_ff_path(self, benzene_xml):
-        ff_xml_path, ff_type = find_xml_ff(benzene_xml)
-        assert ff_type == FF_Types.XML
+        ff_xml_path = find_xml_ff(benzene_xml)
         assert os.path.exists(ff_xml_path)
 
     def test_find_xml_invalid_extension(self):

--- a/hoomd_organics/tests/utils/test_ff_utils.py
+++ b/hoomd_organics/tests/utils/test_ff_utils.py
@@ -28,6 +28,10 @@ class TestFFUtils(BaseTest):
         with pytest.raises(ValueError):
             find_xml_ff("oplsaa.txt")
 
+    def test_find_xml_invalid_file(self, benzene_mol2):
+        with pytest.raises(ValueError):
+            find_xml_ff(benzene_mol2)
+
     def test_find_xml_not_supported_name(self):
         with pytest.raises(ValueError):
             find_xml_ff("oplsaa2")

--- a/hoomd_organics/tests/utils/test_ff_utils.py
+++ b/hoomd_organics/tests/utils/test_ff_utils.py
@@ -1,10 +1,41 @@
+import os
+
+import pytest
 from gmso.core.forcefield import ForceField
 
 from hoomd_organics.tests import BaseTest
-from hoomd_organics.utils import xml_to_gmso_ff
+from hoomd_organics.utils.base_types import FF_Types
+from hoomd_organics.utils.ff_utils import find_xml_ff, xml_to_gmso_ff
 
 
 class TestFFUtils(BaseTest):
+    def test_find_xml_ff(self):
+        ff_xml_path, ff_type = find_xml_ff("oplsaa.xml")
+        assert ff_type == FF_Types.XML
+        assert os.path.exists(ff_xml_path)
+
+    def test_find_xml_only_file_name(self):
+        ff_xml_path, ff_type = find_xml_ff("oplsaa")
+        assert ff_type == FF_Types.XML
+        assert os.path.exists(ff_xml_path)
+
+    def test_find_xml_ff_path(self, benzene_xml):
+        ff_xml_path, ff_type = find_xml_ff(benzene_xml)
+        assert ff_type == FF_Types.XML
+        assert os.path.exists(ff_xml_path)
+
+    def test_find_xml_invalid_extension(self):
+        with pytest.raises(ValueError):
+            find_xml_ff("oplsaa.txt")
+
+    def test_find_xml_not_supported_name(self):
+        with pytest.raises(ValueError):
+            find_xml_ff("oplsaa2")
+
+    def test_find_xml_not_supported_path(self):
+        with pytest.raises(ValueError):
+            find_xml_ff("oplsaa2.xml")
+
     def test_xml_to_gmso_ff(self, benzene_xml):
         gmso_ff = xml_to_gmso_ff(benzene_xml)
         assert isinstance(gmso_ff, ForceField)

--- a/hoomd_organics/utils/__init__.py
+++ b/hoomd_organics/utils/__init__.py
@@ -1,5 +1,5 @@
 from .actions import *
-from .base_types import FF_Types, HOOMDThermostats
+from .base_types import HOOMDThermostats
 from .ff_utils import xml_to_gmso_ff
 from .utils import (
     calculate_box_length,

--- a/hoomd_organics/utils/base_types.py
+++ b/hoomd_organics/utils/base_types.py
@@ -2,12 +2,8 @@ import hoomd
 
 
 class FF_Types:
-    opls = "opls"
-    pps_opls = "pps_opls"
-    oplsaa = "oplsaa"
-    gaff = "gaff"
-    custom = "custom"
-    Hoomd = "Hoomd"
+    XML = "XML"
+    HOOMD = "HOOMD"
 
 
 class HOOMDThermostats:

--- a/hoomd_organics/utils/base_types.py
+++ b/hoomd_organics/utils/base_types.py
@@ -1,11 +1,6 @@
 import hoomd
 
 
-class FF_Types:
-    XML = "XML"
-    HOOMD = "HOOMD"
-
-
 class HOOMDThermostats:
     BERENDSEN = hoomd.md.methods.thermostats.Berendsen
     BUSSI = hoomd.md.methods.thermostats.Bussi

--- a/hoomd_organics/utils/ff_utils.py
+++ b/hoomd_organics/utils/ff_utils.py
@@ -33,7 +33,7 @@ def find_xml_ff(ff_source):
         if not ff_source.endswith(".xml"):
             raise ValueError("ForceField file type must be XML.")
         ff_xml_path = ff_source
-        ff_type = FF_Types.custom
+        ff_type = FF_Types.XML
     elif not xml_directory.get(ff_source.split(".xml")[0]):
         raise ValueError(
             "{} forcefield is not supported. Supported XML forcefields "
@@ -42,7 +42,7 @@ def find_xml_ff(ff_source):
     else:
         ff_key = ff_source.split(".xml")[0]
         ff_xml_path = xml_directory.get(ff_key)
-        ff_type = getattr(FF_Types, ff_key)
+        ff_type = FF_Types.XML
     return ff_xml_path, ff_type
 
 

--- a/hoomd_organics/utils/ff_utils.py
+++ b/hoomd_organics/utils/ff_utils.py
@@ -6,7 +6,6 @@ from gmso.parameterization import apply
 
 from hoomd_organics.assets import FF_DIR
 
-from .base_types import FF_Types
 from .exceptions import (
     MissingAnglePotentialError,
     MissingBondPotentialError,
@@ -33,7 +32,6 @@ def find_xml_ff(ff_source):
         if not ff_source.endswith(".xml"):
             raise ValueError("ForceField file type must be XML.")
         ff_xml_path = ff_source
-        ff_type = FF_Types.XML
     elif not xml_directory.get(ff_source.split(".xml")[0]):
         raise ValueError(
             "{} forcefield is not supported. Supported XML forcefields "
@@ -42,12 +40,11 @@ def find_xml_ff(ff_source):
     else:
         ff_key = ff_source.split(".xml")[0]
         ff_xml_path = xml_directory.get(ff_key)
-        ff_type = FF_Types.XML
-    return ff_xml_path, ff_type
+    return ff_xml_path
 
 
 def xml_to_gmso_ff(ff_xml):
-    ff_xml_path, ff_type = find_xml_ff(ff_xml)
+    ff_xml_path = find_xml_ff(ff_xml)
     gmso_ff = ffutils.FoyerFFs().load(ff_xml_path).to_gmso_ff()
     return gmso_ff
 


### PR DESCRIPTION
This PR applies  following changes to the  Molecule and System classes:

1) Move `force_field`  and `auto_scale` parameters from `System` init to `apply_forcefield` method.
  Since applying forcefield is now done after system initialization, it makes sense to move all forcefield related parameters to `apply_forcefield`. 
  The `apply_forcefield` method always sets the `reference_values` dictionary. When `auto_scale=True` the reference values will be set  based on the maximum parameter value and when its false, the values are set to 1 with default gmso units. As a result, we should always use `reference_values`  as the `base_units` parameter when calling gmso hoomd functions.

2) Added base classes for forcefield
Two new classes are added to the base module: `BaseXMLForcefield` and `BaseHOOMDForcefield`. All the forcefield classes defined in the library now inherit from one of these two base classes. The base classes do not have any additional functionalities, they are defined to ensure all subclasses have similar attribute names. This consistency in attribute names is needed in forcefield validations done in System and Molecule classes.


3) Allow forcefield to be specified in Molecule class
We can pass a valid forcefield to the Molecule class when initializing the molecules. In this case, `apply_forcefield` can be called without passing the forcefields and the system class uses the forcefields from the molecules.
Note: Previously, the `Molecule` class had the forcefield parameter but the accepted types were either direct xml files or list of hoomd objects. With the changes in this PR, only valid forcefields, i.e. subclasses of the base forcefield classes, can be passed to the Molecule.

